### PR TITLE
Propagate reqwest timeout error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,19 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "socket2 0.6.0",
+ "tokio-macros",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ reqwest = { version = "0.12", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time"], default-features = false }
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Summary
- preserve original `reqwest::Error` text in timeout mapping
- add async test verifying timeout message includes upstream error
- add tokio dev-dependency for test runtime

## Testing
- `cargo clippy --all-targets --features "reqwest tokio" -- -D warnings`
- `cargo build --all-targets --features "reqwest tokio"`
- `cargo test --all --features "reqwest tokio"`
- `cargo doc --no-deps --features "reqwest tokio turnkey"`


------
https://chatgpt.com/codex/tasks/task_e_68c26562aa68832b9ff2080b2e4372cf