### PR TITLE
Fix status code conversions

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -184,7 +184,7 @@ impl ErrorResponse {
     /// use http::StatusCode;
     /// use masterror::{AppCode, ErrorResponse};
     ///
-    /// let resp = ErrorResponse::new(404, AppCode::NotFound, "missing");
+    /// let resp = ErrorResponse::new(404, AppCode::NotFound, "missing").expect("status");
     /// assert_eq!(resp.status_code(), StatusCode::NOT_FOUND);
     /// ```
     #[must_use]
@@ -315,7 +315,10 @@ mod actix_impl {
     use actix_web::{
         HttpRequest, HttpResponse, Responder,
         body::BoxBody,
-        http::header::{RETRY_AFTER, WWW_AUTHENTICATE}
+        http::{
+            StatusCode as ActixStatus,
+            header::{RETRY_AFTER, WWW_AUTHENTICATE}
+        }
     };
 
     use super::ErrorResponse;
@@ -325,6 +328,8 @@ mod actix_impl {
 
         fn respond_to(self, _req: &HttpRequest) -> HttpResponse {
             let status = self.status_code();
+            let status = ActixStatus::from_u16(status.as_u16())
+                .unwrap_or(ActixStatus::INTERNAL_SERVER_ERROR);
 
             let mut builder = HttpResponse::build(status);
             if let Some(retry) = self.retry {
@@ -377,10 +382,17 @@ mod tests {
     fn status_code_maps_invalid_to_internal_server_error() {
         use http::StatusCode;
 
-        let valid = ErrorResponse::new(404, AppCode::NotFound, "missing");
+        let valid = ErrorResponse::new(404, AppCode::NotFound, "missing").expect("status");
         assert_eq!(valid.status_code(), StatusCode::NOT_FOUND);
 
-        let invalid = ErrorResponse::new(1000, AppCode::Internal, "oops");
+        let invalid = ErrorResponse {
+            status:           1000,
+            code:             AppCode::Internal,
+            message:          "oops".into(),
+            details:          None,
+            retry:            None,
+            www_authenticate: None
+        };
         assert_eq!(invalid.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 


### PR DESCRIPTION
## Summary
- convert `ErrorResponse` status into `actix_web`'s `StatusCode`
- adjust tests for `status_code()` helper and update docs

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps --all-features`
- `cargo audit` *(fails: 1 vulnerability found in `rsa` via `sqlx`)*
- `cargo check --no-default-features --features axum`
- `cargo check --no-default-features --features actix`


------
https://chatgpt.com/codex/tasks/task_e_68c26935bddc832b859d35648bdaf188