### PR TITLE
feat: add duration-based retry helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- `ErrorResponse::with_retry_after_duration` helper for specifying retry advice via `Duration`.
+
 ## [0.3.3] - 2025-09-11
 ### Added
 - `ErrorResponse::status_code()` exposing validated `StatusCode`.

--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ fn do_work(flag: bool) -> AppResult<()> {
 
 ~~~rust
 use masterror::{AppError, AppErrorKind, AppCode, ErrorResponse};
+use std::time::Duration;
 
 let app_err = AppError::new(AppErrorKind::Unauthorized, "Token expired");
 let resp: ErrorResponse = (&app_err).into()
-    .with_retry_after_secs(30)
+    .with_retry_after_duration(Duration::from_secs(30))
     .with_www_authenticate(r#"Bearer realm="api", error="invalid_token""#);
 
 assert_eq!(resp.status, 401);
@@ -244,7 +245,7 @@ assert_eq!(app.kind, AppErrorKind::RateLimited);
   <summary><b>Migration 0.2 → 0.3</b></summary>
 
 - Use `ErrorResponse::new(status, AppCode::..., "msg")` instead of legacy  
-- New helpers: `.with_retry_after_secs`, `.with_www_authenticate`  
+- New helpers: `.with_retry_after_secs`, `.with_retry_after_duration`, `.with_www_authenticate`
 - `ErrorResponse::new_legacy` is temporary shim  
 
 </details>


### PR DESCRIPTION
## Summary
- allow specifying retry advice via `Duration`
- document duration-based helper alongside seconds API

## Testing
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c275e9fb80832b8aaa530583a8d469