### PR TITLE
docs: record recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 - `ErrorResponse::with_retry_after_duration` helper for specifying retry advice via `Duration`.
 
+### Changed
+- `AppError::log` now includes the stable `code` field alongside `kind`.
+- `AppError` stores messages as `Cow<'static, str>` to avoid unnecessary allocations.
+
 ## [0.3.3] - 2025-09-11
 ### Added
 - `ErrorResponse::status_code()` exposing validated `StatusCode`.

--- a/src/response.rs
+++ b/src/response.rs
@@ -61,7 +61,8 @@
 
 use std::{
     borrow::Cow,
-    fmt::{Display, Formatter, Result as FmtResult}
+    fmt::{Display, Formatter, Result as FmtResult},
+    time::Duration
 };
 
 use http::StatusCode;


### PR DESCRIPTION
## Summary
- mention logging code and Cow message in changelog
- import `Duration` for retry helper

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c277a6ab94832bac9c787d398c971d