### PR TITLE
test: check service fallback for unknown turnkey message

### DIFF
--- a/src/turnkey.rs
+++ b/src/turnkey.rs
@@ -326,6 +326,14 @@ mod tests {
     }
 
     #[test]
+    fn classifier_service_fallback() {
+        assert!(matches!(
+            classify_turnkey_error("unrecognized issue"),
+            TurnkeyErrorKind::Service
+        ));
+    }
+
+    #[test]
     fn contains_nocase_works_without_alloc() {
         assert!(contains_nocase("ABCdef", "cDe"));
         assert!(contains_any_nocase("hello world", &["nope", "WORLD"]));


### PR DESCRIPTION
## Summary
- verify classify_turnkey_error defaults to `Service`

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c27a263070832b87ea334a89b5f2e4