### PR TITLE
docs: explain config error mapping

### DIFF
--- a/src/convert/config.rs
+++ b/src/convert/config.rs
@@ -1,3 +1,18 @@
+//! Convert [`config::ConfigError`] into [`AppError`],
+//! producing [`AppErrorKind::Config`].
+//!
+//! Enabled with the `config` feature.
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use config::ConfigError;
+//! use masterror::{AppError, AppErrorKind};
+//!
+//! let err = ConfigError::Message("missing key".into());
+//! let app_err: AppError = err.into();
+//! assert!(matches!(app_err.kind, AppErrorKind::Config));
+//! ```
 #[cfg(feature = "config")]
 use config::ConfigError;
 
@@ -5,8 +20,23 @@ use config::ConfigError;
 use crate::AppError;
 
 #[cfg(feature = "config")]
+#[cfg_attr(docsrs, doc(cfg(feature = "config")))]
 impl From<ConfigError> for AppError {
     fn from(err: ConfigError) -> Self {
         AppError::config(err.to_string())
+    }
+}
+
+#[cfg(all(test, feature = "config"))]
+mod tests {
+    use config::ConfigError;
+
+    use crate::{AppError, AppErrorKind};
+
+    #[test]
+    fn maps_to_config_kind() {
+        let err = ConfigError::Message("dummy".into());
+        let app_err = AppError::from(err);
+        assert!(matches!(app_err.kind, AppErrorKind::Config));
     }
 }


### PR DESCRIPTION
## Summary
- document mapping of `config::ConfigError` to `AppErrorKind::Config`
- test conversion from `ConfigError` to `AppError`

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --features config -- -D warnings`
- `cargo build --all-targets`
- `cargo build --all-targets --features config`
- `cargo test --all`
- `cargo test --all --features config`
- `cargo doc --no-deps`
- `cargo doc --no-deps --features config`


------
https://chatgpt.com/codex/tasks/task_e_68c27a1d91e0832b95d242d9c2b3e92a