### PR TITLE
docs: sync changelog and README for error mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project will be documented in this file.
 - `AppError::log` now includes the stable `code` field alongside `kind`.
 - `AppError` stores messages as `Cow<'static, str>` to avoid unnecessary allocations.
 
+### Documentation
+- Clarified how `config::ConfigError` converts into `AppErrorKind::Config`.
+- Documented that `MultipartError` maps to `AppErrorKind::BadRequest` in the Axum adapter.
+
+### Tests
+- Added unit test verifying `config::ConfigError` mapping.
+- Added Axum test asserting `MultipartError` becomes `AppErrorKind::BadRequest` and preserves the message.
+- Expanded Actix test to check JSON body and `Retry-After`/`WWW-Authenticate` headers.
+- Covered fallback classification of unknown messages as `TurnkeyErrorKind::Service`.
+
 ## [0.3.3] - 2025-09-11
 ### Added
 - `ErrorResponse::status_code()` exposing validated `StatusCode`.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ utoipa = "5"
 - `sqlx::Error` → NotFound/Database
 - `redis::RedisError` → Cache
 - `reqwest::Error` → Timeout/Network/ExternalApi
+- `axum::extract::multipart::MultipartError` → BadRequest
 - `validator::ValidationErrors` → Validation
 - `config::ConfigError` → Config
 - `tokio::time::error::Elapsed` → Timeout


### PR DESCRIPTION
## Summary
- document ConfigError and MultipartError mappings in CHANGELOG
- list MultipartError conversion in README
- note expanded tests for Actix, Axum, and Turnkey

## Testing
- `cargo +nightly fmt --`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c2796f9660832bac07179c37df7f6d