### PR TITLE
Use AppResult alias across the crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ utoipa = "5"
 
 ~~~rust
 // features = ["frontend"]
-use masterror::{AppError, AppErrorKind};
+use masterror::{AppError, AppErrorKind, AppResult};
 use masterror::frontend::{BrowserConsoleError, BrowserConsoleExt};
 
-fn report() -> Result<(), BrowserConsoleError> {
+fn report() -> AppResult<(), BrowserConsoleError> {
     let err = AppError::bad_request("missing field");
     let payload = err.to_js_value()?;
     assert!(payload.is_object());

--- a/src/app_error.rs
+++ b/src/app_error.rs
@@ -83,7 +83,29 @@ pub struct AppError {
 }
 
 /// Conventional result alias for application code.
-pub type AppResult<T> = Result<T, AppError>;
+///
+/// The alias defaults to [`AppError`] but accepts a custom error type when the
+/// context requires a different domain error.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::io::Error;
+///
+/// use masterror::AppResult;
+///
+/// fn app_logic() -> AppResult<u8> {
+///     Ok(7)
+/// }
+///
+/// fn io_logic() -> AppResult<(), Error> {
+///     Ok(())
+/// }
+///
+/// assert_eq!(app_logic().unwrap(), 7);
+/// assert!(io_logic().is_ok());
+/// ```
+pub type AppResult<T, E = AppError> = Result<T, E>;
 
 impl AppError {
     /// Create a new [`AppError`] with a kind and message.
@@ -526,15 +548,20 @@ mod tests {
         fn err() -> AppResult<u8> {
             Err(AppError::internal("x"))
         }
+        fn other_err() -> AppResult<u8, &'static str> {
+            Err("boom")
+        }
 
         let a: AppResult<u8> = ok();
         let b: AppResult<u8> = err();
+        let c: AppResult<u8, &'static str> = other_err();
 
         assert_eq!(a.unwrap(), 1);
         assert!(b.is_err());
         if let Err(e) = b {
             assert!(matches!(e.kind, AppErrorKind::Internal));
         }
+        assert_eq!(c.unwrap_err(), "boom");
     }
 
     // --- Logging path sanity check -------------------------------------------

--- a/src/convert/actix.rs
+++ b/src/convert/actix.rs
@@ -35,8 +35,10 @@
 //!     Err(AppError::new(AppErrorKind::Forbidden, "no access"))
 //! }
 //!
+//! use std::io::Error;
+//!
 //! #[actix_web::main]
-//! async fn main() -> std::io::Result<()> {
+//! async fn main() -> AppResult<(), Error> {
 //!     HttpServer::new(|| App::new().service(forbidden))
 //!         .bind(("127.0.0.1", 8080))?
 //!         .run()
@@ -103,7 +105,7 @@ mod actix_tests {
         http::header::{RETRY_AFTER, WWW_AUTHENTICATE}
     };
 
-    use crate::{AppCode, AppError, AppErrorKind, ErrorResponse};
+    use crate::{AppCode, AppError, AppErrorKind, AppResult, ErrorResponse};
 
     #[test]
     fn maps_status_consistently() {
@@ -112,7 +114,7 @@ mod actix_tests {
     }
 
     #[actix_web::test] // ← вот это
-    async fn error_response_sets_body_and_headers() -> Result<(), Box<dyn std::error::Error>> {
+    async fn error_response_sets_body_and_headers() -> AppResult<(), Box<dyn std::error::Error>> {
         let err = AppError::unauthorized("no token")
             .with_retry_after_secs(7)
             .with_www_authenticate("Bearer");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! - [`AppError`] — thin wrapper around a semantic error kind and optional
 //!   message
 //! - [`AppErrorKind`] — stable internal taxonomy of application errors
-//! - [`AppResult`] — convenience alias for returning [`AppError`]
+//! - [`AppResult`] — convenience result alias (defaults to [`AppError`])
 //! - [`ErrorResponse`] — stable wire-level JSON payload for HTTP APIs
 //! - [`AppCode`] — public, machine-readable error code for clients
 //!


### PR DESCRIPTION
## Summary
- generalize the `AppResult` type alias to accept alternate error types and document the behavior
- replace remaining `Result` return types in the frontend helpers with `AppResult` and update the README example
- update the Actix integration test and docs to leverage `AppResult` for consistency across the crate

## Testing
- cargo +nightly fmt --
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --all-targets --all-features
- cargo test --all-features
- cargo doc --no-deps --all-features


------
https://chatgpt.com/codex/tasks/task_e_68c9fa29f338832b9937e25a7ec080bd