### PR TITLE
feat(derive): support #[from] conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,6 +1515,7 @@ dependencies = [
  "teloxide-core",
  "tokio",
  "tracing",
+ "trybuild",
  "utoipa",
  "validator",
  "wasm-bindgen",
@@ -2700,6 +2707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20f34339676cdcab560c9a82300c4c2581f68b9369aedf0fae86f2ff9565ff3e"
 
 [[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
 name = "telegram-webapp-sdk"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +2766,15 @@ dependencies = [
  "tokio-util",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2889,10 +2911,12 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
+ "indexmap 2.11.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -2913,6 +2937,12 @@ checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -2996,6 +3026,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ded9fdb81f30a5708920310bfcd9ea7482ff9cba5f54601f7a19a877d5c2392"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "typeid"
@@ -3296,6 +3341,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ tokio = { version = "1", features = [
   "net",
   "time",
 ], default-features = false }
+trybuild = "1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/masterror-derive/src/lib.rs
+++ b/masterror-derive/src/lib.rs
@@ -4,8 +4,9 @@
 //! Derive macro implementing [`std::error::Error`] with `Display` formatting.
 //!
 //! The macro mirrors the essential functionality relied upon by `masterror` and
-//! consumers of the crate: display strings with named or positional fields and
-//! a configurable error source via `#[source]` field attributes.
+//! consumers of the crate: display strings with named or positional fields,
+//! `#[from]` conversions for wrapper types, and a configurable error source via
+//! `#[source]` field attributes.
 
 use std::collections::BTreeSet;
 
@@ -21,7 +22,7 @@ use syn::{
 /// enums.
 ///
 /// ```
-/// use masterror::Error;
+/// use masterror_derive::Error;
 ///
 /// #[derive(Debug, Error)]
 /// #[error("{code}: {message}")]
@@ -35,9 +36,9 @@ use syn::{
 ///     message: "boom"
 /// };
 /// assert_eq!(err.to_string(), "500: boom");
-/// assert!(err.source().is_none());
+/// assert!(std::error::Error::source(&err).is_none());
 /// ```
-#[proc_macro_derive(Error, attributes(error, source))]
+#[proc_macro_derive(Error, attributes(error, source, from))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     match derive_error_impl(syn::parse_macro_input!(input as DeriveInput)) {
         Ok(tokens) => tokens.into(),
@@ -51,6 +52,7 @@ fn derive_error_impl(input: DeriveInput) -> syn::Result<TokenStream2> {
 
     let display_impl;
     let error_impl;
+    let from_impls;
 
     match input.data {
         Data::Struct(data) => {
@@ -58,11 +60,13 @@ fn derive_error_impl(input: DeriveInput) -> syn::Result<TokenStream2> {
             let display_attr = parse_display_attr(&input.attrs)?;
             display_impl = build_struct_display(&ident, &generics, &fields, &display_attr)?;
             error_impl = build_struct_error(&ident, &generics, &fields)?;
+            from_impls = build_struct_from_impl(&ident, &generics, &fields)?;
         }
         Data::Enum(data) => {
             let variants = parse_enum(&data)?;
             display_impl = build_enum_display(&ident, &generics, &variants)?;
             error_impl = build_enum_error(&ident, &generics, &variants)?;
+            from_impls = build_enum_from_impls(&ident, &generics, &variants)?;
         }
         Data::Union(_) => {
             return Err(syn::Error::new(
@@ -75,6 +79,7 @@ fn derive_error_impl(input: DeriveInput) -> syn::Result<TokenStream2> {
     Ok(quote! {
         #display_impl
         #error_impl
+        #from_impls
     })
 }
 
@@ -89,7 +94,45 @@ enum FieldsStyle {
 struct FieldSpec {
     member:  Member,
     ident:   Option<Ident>,
-    binding: Ident
+    binding: Ident,
+    ty:      Type,
+    attrs:   FieldAttributes
+}
+
+#[derive(Clone, Default)]
+struct FieldAttributes {
+    from:   Option<Span>,
+    source: Option<Span>
+}
+
+impl FieldAttributes {
+    fn mark_from(&mut self, span: Span) -> syn::Result<()> {
+        if self.from.is_some() {
+            return Err(syn::Error::new(span, "duplicate #[from] attribute"));
+        }
+        self.from = Some(span);
+        Ok(())
+    }
+
+    fn mark_source(&mut self, span: Span) -> syn::Result<()> {
+        if self.source.is_some() {
+            return Err(syn::Error::new(span, "duplicate #[source] attribute"));
+        }
+        self.source = Some(span);
+        Ok(())
+    }
+
+    fn has_source(&self) -> bool {
+        self.source.is_some()
+    }
+
+    fn span_of_from_attribute(&self) -> Option<Span> {
+        self.from
+    }
+
+    fn source_span(&self) -> Option<Span> {
+        self.source
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -116,6 +159,11 @@ struct VariantInfo {
     display: LitStr
 }
 
+struct FromFieldInfo<'a> {
+    field: &'a FieldSpec,
+    span:  Span
+}
+
 struct RewriteResult {
     literal:            LitStr,
     positional_indices: BTreeSet<usize>
@@ -129,7 +177,10 @@ fn parse_enum(data: &DataEnum) -> syn::Result<Vec<VariantInfo>> {
     let mut variants = Vec::with_capacity(data.variants.len());
     for variant in &data.variants {
         let display = parse_display_attr(&variant.attrs)?;
-        let fields = parse_fields_internal(&variant.fields)?;
+        let mut fields = parse_fields_internal(&variant.fields)?;
+        if let Some(span) = parse_variant_from_attr(&variant.attrs)? {
+            apply_variant_from_attr(&mut fields, span, &variant.ident)?;
+        }
         variants.push(VariantInfo {
             ident: variant.ident.clone(),
             fields,
@@ -150,16 +201,17 @@ fn parse_fields_internal(fields: &Fields) -> syn::Result<ParsedFields> {
             let mut specs = Vec::with_capacity(named.named.len());
             let mut source = None;
             for (index, field) in named.named.iter().enumerate() {
+                let attrs = parse_field_attributes(field)?;
                 let ident = field.ident.clone().ok_or_else(|| {
                     syn::Error::new(field.span(), "named field missing identifier")
                 })?;
                 let member = Member::Named(ident.clone());
                 let binding = ident.clone();
-                if has_source_attr(field)? {
+                if attrs.has_source() {
                     let kind = detect_source_kind(&field.ty)?;
                     if source.is_some() {
                         return Err(syn::Error::new(
-                            field.span(),
+                            attrs.source_span().unwrap_or_else(|| field.span()),
                             "only a single #[source] field is supported"
                         ));
                     }
@@ -171,7 +223,9 @@ fn parse_fields_internal(fields: &Fields) -> syn::Result<ParsedFields> {
                 specs.push(FieldSpec {
                     member,
                     ident: Some(ident),
-                    binding
+                    binding,
+                    ty: field.ty.clone(),
+                    attrs
                 });
             }
             Ok(ParsedFields {
@@ -184,13 +238,14 @@ fn parse_fields_internal(fields: &Fields) -> syn::Result<ParsedFields> {
             let mut specs = Vec::with_capacity(unnamed.unnamed.len());
             let mut source = None;
             for (index, field) in unnamed.unnamed.iter().enumerate() {
+                let attrs = parse_field_attributes(field)?;
                 let member = Member::Unnamed(index.into());
                 let binding = format_ident!("__masterror_{index}");
-                if has_source_attr(field)? {
+                if attrs.has_source() {
                     let kind = detect_source_kind(&field.ty)?;
                     if source.is_some() {
                         return Err(syn::Error::new(
-                            field.span(),
+                            attrs.source_span().unwrap_or_else(|| field.span()),
                             "only a single #[source] field is supported"
                         ));
                     }
@@ -202,7 +257,9 @@ fn parse_fields_internal(fields: &Fields) -> syn::Result<ParsedFields> {
                 specs.push(FieldSpec {
                     member,
                     ident: None,
-                    binding
+                    binding,
+                    ty: field.ty.clone(),
+                    attrs
                 });
             }
             Ok(ParsedFields {
@@ -240,20 +297,101 @@ fn parse_display_attr(attrs: &[Attribute]) -> syn::Result<LitStr> {
         .ok_or_else(|| syn::Error::new(Span::call_site(), r#"missing #[error("...")] attribute"#))
 }
 
-fn has_source_attr(field: &Field) -> syn::Result<bool> {
-    let mut found = false;
+fn parse_field_attributes(field: &Field) -> syn::Result<FieldAttributes> {
+    let mut attrs = FieldAttributes::default();
     for attr in &field.attrs {
         if attr.path().is_ident("source") {
-            if found {
-                return Err(syn::Error::new(
-                    attr.span(),
-                    "duplicate #[source] attribute"
-                ));
-            }
-            found = true;
+            ensure_path_only(attr, "source")?;
+            attrs.mark_source(attr.span())?;
+        } else if attr.path().is_ident("from") {
+            ensure_path_only(attr, "from")?;
+            attrs.mark_from(attr.span())?;
         }
     }
-    Ok(found)
+    Ok(attrs)
+}
+
+fn ensure_path_only(attr: &Attribute, name: &str) -> syn::Result<()> {
+    if !matches!(&attr.meta, Meta::Path(_)) {
+        return Err(syn::Error::new(
+            attr.span(),
+            format!("#[{name}] attribute does not accept arguments")
+        ));
+    }
+    Ok(())
+}
+
+fn parse_variant_from_attr(attrs: &[Attribute]) -> syn::Result<Option<Span>> {
+    let mut span = None;
+    for attr in attrs.iter().filter(|attr| attr.path().is_ident("from")) {
+        ensure_path_only(attr, "from")?;
+        if span.is_some() {
+            return Err(syn::Error::new(attr.span(), "duplicate #[from] attribute"));
+        }
+        span = Some(attr.span());
+    }
+    Ok(span)
+}
+
+fn apply_variant_from_attr(
+    fields: &mut ParsedFields,
+    span: Span,
+    variant_ident: &Ident
+) -> syn::Result<()> {
+    if fields.fields.is_empty() {
+        return Err(syn::Error::new(
+            span,
+            format!(
+                "variant `{variant_ident}` marked with #[from] must contain exactly one field"
+            )
+        ));
+    }
+    if fields.fields.len() != 1 {
+        return Err(syn::Error::new(
+            span,
+            format!(
+                "variant `{variant_ident}` marked with #[from] must contain exactly one field"
+            )
+        ));
+    }
+    let field = fields
+        .fields
+        .get_mut(0)
+        .ok_or_else(|| syn::Error::new(span, "invalid #[from] field index"))?;
+    field.attrs.mark_from(span)
+}
+
+fn find_from_field<'a>(
+    fields: &'a ParsedFields,
+    context: &str
+) -> syn::Result<Option<FromFieldInfo<'a>>> {
+    let mut info = None;
+    for field in &fields.fields {
+        if let Some(span) = field.attrs.span_of_from_attribute() {
+            if info.is_some() {
+                return Err(syn::Error::new(
+                    span,
+                    format!(
+                        "multiple #[from] attributes in {context}; only one field may use #[from]"
+                    )
+                ));
+            }
+            info = Some(FromFieldInfo {
+                field,
+                span
+            });
+        }
+    }
+    let Some(info) = info else {
+        return Ok(None);
+    };
+    if fields.fields.len() != 1 {
+        return Err(syn::Error::new(
+            info.span,
+            format!("using #[from] in {context} requires exactly one field")
+        ));
+    }
+    Ok(Some(info))
 }
 
 fn detect_source_kind(ty: &Type) -> syn::Result<SourceKind> {
@@ -398,6 +536,52 @@ fn build_struct_error(
         impl #impl_generics ::std::error::Error for #ident #ty_generics #where_clause {
             fn source(&self) -> ::core::option::Option<&(dyn ::std::error::Error + 'static)> {
                 #source_expr
+            }
+        }
+    })
+}
+
+fn build_struct_from_impl(
+    ident: &Ident,
+    generics: &Generics,
+    fields: &ParsedFields
+) -> syn::Result<TokenStream2> {
+    let context = format!("struct `{ident}`");
+    let Some(from_info) = find_from_field(fields, &context)? else {
+        return Ok(TokenStream2::new());
+    };
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let field_ty = &from_info.field.ty;
+    let arg_ident = format_ident!("__masterror_from_value");
+
+    let construct = match fields.style {
+        FieldsStyle::Named => {
+            let field_ident = from_info.field.ident.clone().ok_or_else(|| {
+                syn::Error::new(from_info.span, "named field missing identifier")
+            })?;
+            quote! { Self { #field_ident: #arg_ident } }
+        }
+        FieldsStyle::Unnamed => {
+            if fields.fields.len() != 1 {
+                return Err(syn::Error::new(
+                    from_info.span,
+                    format!("using #[from] in {context} requires exactly one field")
+                ));
+            }
+            quote! { Self(#arg_ident) }
+        }
+        FieldsStyle::Unit => {
+            return Err(syn::Error::new(
+                from_info.span,
+                format!("using #[from] in {context} requires at least one field")
+            ));
+        }
+    };
+
+    Ok(quote! {
+        impl #impl_generics ::core::convert::From<#field_ty> for #ident #ty_generics #where_clause {
+            fn from(#arg_ident: #field_ty) -> Self {
+                #construct
             }
         }
     })
@@ -596,6 +780,58 @@ fn build_enum_error(
             }
         }
     })
+}
+
+fn build_enum_from_impls(
+    ident: &Ident,
+    generics: &Generics,
+    variants: &[VariantInfo]
+) -> syn::Result<TokenStream2> {
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let mut impls = Vec::new();
+
+    for variant in variants {
+        let context = format!("variant `{}`", variant.ident);
+        if let Some(from_info) = find_from_field(&variant.fields, &context)? {
+            let field_ty = &from_info.field.ty;
+            let variant_ident = &variant.ident;
+            let arg_ident = format_ident!("__masterror_from_value");
+
+            let body = match variant.fields.style {
+                FieldsStyle::Named => {
+                    let field_ident = from_info.field.ident.clone().ok_or_else(|| {
+                        syn::Error::new(from_info.span, "named field missing identifier")
+                    })?;
+                    quote! { Self::#variant_ident { #field_ident: #arg_ident } }
+                }
+                FieldsStyle::Unnamed => {
+                    if variant.fields.fields.len() != 1 {
+                        return Err(syn::Error::new(
+                            from_info.span,
+                            format!("using #[from] in {context} requires exactly one field")
+                        ));
+                    }
+                    quote! { Self::#variant_ident(#arg_ident) }
+                }
+                FieldsStyle::Unit => {
+                    return Err(syn::Error::new(
+                        from_info.span,
+                        format!("{context} cannot be unit-like when using #[from]")
+                    ));
+                }
+            };
+
+            impls.push(quote! {
+                impl #impl_generics ::core::convert::From<#field_ty> for #ident #ty_generics #where_clause {
+                    fn from(#arg_ident: #field_ty) -> Self {
+                        #body
+                    }
+                }
+            });
+        }
+    }
+
+    Ok(quote! { #(#impls)* })
 }
 
 fn rewrite_format_string(original: &LitStr, field_count: usize) -> syn::Result<RewriteResult> {

--- a/tests/error_derive.rs
+++ b/tests/error_derive.rs
@@ -33,6 +33,48 @@ enum EnumError {
     Pair(String, #[source] LeafError)
 }
 
+#[derive(Debug, Error)]
+#[error("primary failure")]
+struct PrimaryError;
+
+#[derive(Debug, Error)]
+#[error("secondary failure")]
+struct SecondaryError;
+
+#[derive(Debug, Error)]
+#[error("tuple wrapper -> {0}")]
+struct TupleWrapper(
+    #[from]
+    #[source]
+    LeafError
+);
+
+#[derive(Debug, Error)]
+#[error("message: {message}")]
+struct MessageWrapper {
+    #[from]
+    message: String
+}
+
+#[derive(Debug, Error)]
+enum MixedFromError {
+    #[error("tuple variant {0}")]
+    Tuple(
+        #[from]
+        #[source]
+        LeafError
+    ),
+    #[error("variant attr {0}")]
+    #[from]
+    VariantAttr(#[source] PrimaryError),
+    #[error("named variant {source:?}")]
+    Named {
+        #[from]
+        #[source]
+        source: SecondaryError
+    }
+}
+
 #[test]
 fn named_struct_display_and_source() {
     let err = NamedError {
@@ -76,4 +118,48 @@ fn tuple_variant_with_source() {
     let _unit = EnumError::Unit;
     assert!(err.to_string().starts_with("left"));
     assert_eq!(StdError::source(&err).unwrap().to_string(), "leaf failure");
+}
+
+#[test]
+fn tuple_struct_from_wraps_source() {
+    let err = TupleWrapper::from(LeafError);
+    assert_eq!(err.to_string(), "tuple wrapper -> leaf failure");
+    let source = StdError::source(&err).expect("source present");
+    assert_eq!(source.to_string(), "leaf failure");
+}
+
+#[test]
+fn named_struct_from_without_source() {
+    let err = MessageWrapper::from(String::from("payload"));
+    assert_eq!(err.to_string(), "message: payload");
+    assert!(StdError::source(&err).is_none());
+}
+
+#[test]
+fn enum_from_variants_generate_impls() {
+    let tuple = MixedFromError::from(LeafError);
+    assert!(matches!(&tuple, MixedFromError::Tuple(_)));
+    assert_eq!(
+        StdError::source(&tuple).unwrap().to_string(),
+        "leaf failure"
+    );
+
+    let variant_attr = MixedFromError::from(PrimaryError);
+    assert!(matches!(&variant_attr, MixedFromError::VariantAttr(_)));
+    assert_eq!(
+        StdError::source(&variant_attr).unwrap().to_string(),
+        "primary failure"
+    );
+
+    let named = MixedFromError::from(SecondaryError);
+    assert!(matches!(
+        &named,
+        MixedFromError::Named {
+            source: SecondaryError
+        }
+    ));
+    assert_eq!(
+        StdError::source(&named).unwrap().to_string(),
+        "secondary failure"
+    );
 }

--- a/tests/error_derive_from_trybuild.rs
+++ b/tests/error_derive_from_trybuild.rs
@@ -1,0 +1,7 @@
+use trybuild::TestCases;
+
+#[test]
+fn from_attribute_compile_failures() {
+    let t = TestCases::new();
+    t.compile_fail("tests/ui/from/*.rs");
+}

--- a/tests/ui/from/struct_multiple_fields.rs
+++ b/tests/ui/from/struct_multiple_fields.rs
@@ -1,0 +1,15 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error("{left:?} - {right:?}")]
+struct BadStruct {
+    #[from]
+    left: DummyError,
+    right: DummyError,
+}
+
+#[derive(Debug, Error)]
+#[error("dummy")] 
+struct DummyError;
+
+fn main() {}

--- a/tests/ui/from/struct_multiple_fields.stderr
+++ b/tests/ui/from/struct_multiple_fields.stderr
@@ -1,0 +1,5 @@
+error: using #[from] in struct `BadStruct` requires exactly one field
+ --> tests/ui/from/struct_multiple_fields.rs:6:5
+  |
+6 |     #[from]
+  |     ^

--- a/tests/ui/from/variant_multiple_fields.rs
+++ b/tests/ui/from/variant_multiple_fields.rs
@@ -1,0 +1,14 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+enum BadEnum {
+    #[error("{0} - {1}")]
+    #[from]
+    Two(#[source] DummyError, DummyError),
+}
+
+#[derive(Debug, Error)]
+#[error("dummy")]
+struct DummyError;
+
+fn main() {}

--- a/tests/ui/from/variant_multiple_fields.stderr
+++ b/tests/ui/from/variant_multiple_fields.stderr
@@ -1,0 +1,5 @@
+error: variant `Two` marked with #[from] must contain exactly one field
+ --> tests/ui/from/variant_multiple_fields.rs:6:5
+  |
+6 |     #[from]
+  |     ^


### PR DESCRIPTION
## Summary
- parse the `#[from]` attribute on struct fields and enum variants, integrate it with existing source detection, and emit the matching `From<T>` impls
- reject conflicting usages of `#[from]` while keeping display/source generation intact
- extend the derive tests with runtime coverage and trybuild-based negative cases for the new conversions

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68ca2d3a02bc832bae565f264597a17f