### PR TITLE
Add transparent error support to derive macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `#[error(transparent)]` support in the derive macro: validates wrapper shape,
+  delegates `Display`/`source` to the inner error, and works with `#[from]`.
+
 ## [0.4.0] - 2025-09-15
 ### Added
 - Optional `frontend` feature:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ masterror = { version = "0.4.0", default-features = false }
 - **Opt-in integrations.** Zero default features; you enable what you need.
 - **Clean wire contract.** `ErrorResponse { status, code, message, details?, retry?, www_authenticate? }`.
 - **One log at boundary.** Log once with `tracing`.
-- **Less boilerplate.** Built-in conversions, compact prelude.
+- **Less boilerplate.** Built-in conversions, compact prelude,
+  derive macro support for transparent wrappers via `#[error(transparent)]`.
 - **Consistent workspace.** Same error surface across crates.
 
 </details>

--- a/README.template.md
+++ b/README.template.md
@@ -44,7 +44,8 @@ masterror = { version = "{{CRATE_VERSION}}", default-features = false }
 - **Opt-in integrations.** Zero default features; you enable what you need.
 - **Clean wire contract.** `ErrorResponse { status, code, message, details?, retry?, www_authenticate? }`.
 - **One log at boundary.** Log once with `tracing`.
-- **Less boilerplate.** Built-in conversions, compact prelude.
+- **Less boilerplate.** Built-in conversions, compact prelude,
+  derive macro support for transparent wrappers via `#[error(transparent)]`.
 - **Consistent workspace.** Same error surface across crates.
 
 </details>

--- a/tests/error_derive_from_trybuild.rs
+++ b/tests/error_derive_from_trybuild.rs
@@ -5,3 +5,9 @@ fn from_attribute_compile_failures() {
     let t = TestCases::new();
     t.compile_fail("tests/ui/from/*.rs");
 }
+
+#[test]
+fn transparent_attribute_compile_failures() {
+    let t = TestCases::new();
+    t.compile_fail("tests/ui/transparent/*.rs");
+}

--- a/tests/ui/transparent/enum_variant_multiple_fields.rs
+++ b/tests/ui/transparent/enum_variant_multiple_fields.rs
@@ -1,0 +1,7 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+enum TransparentEnumFail {
+    #[error(transparent)]
+    Variant(String, String)
+}

--- a/tests/ui/transparent/enum_variant_multiple_fields.stderr
+++ b/tests/ui/transparent/enum_variant_multiple_fields.stderr
@@ -1,0 +1,11 @@
+error: using #[error(transparent)] in variant `Variant` requires exactly one field
+ --> tests/ui/transparent/enum_variant_multiple_fields.rs:5:5
+  |
+5 |     #[error(transparent)]
+  |     ^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/transparent/enum_variant_multiple_fields.rs:7:2
+  |
+7 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/ui/transparent/enum_variant_multiple_fields.rs`

--- a/tests/ui/transparent/enum_variant_no_fields.rs
+++ b/tests/ui/transparent/enum_variant_no_fields.rs
@@ -1,0 +1,7 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+enum TransparentEnumUnit {
+    #[error(transparent)]
+    Variant
+}

--- a/tests/ui/transparent/enum_variant_no_fields.stderr
+++ b/tests/ui/transparent/enum_variant_no_fields.stderr
@@ -1,0 +1,11 @@
+error: using #[error(transparent)] in variant `Variant` requires exactly one field
+ --> tests/ui/transparent/enum_variant_no_fields.rs:5:5
+  |
+5 |     #[error(transparent)]
+  |     ^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/transparent/enum_variant_no_fields.rs:7:2
+  |
+7 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/ui/transparent/enum_variant_no_fields.rs`

--- a/tests/ui/transparent/struct_multiple_fields.rs
+++ b/tests/ui/transparent/struct_multiple_fields.rs
@@ -1,0 +1,8 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error(transparent)]
+struct TransparentMany {
+    first: String,
+    second: String
+}

--- a/tests/ui/transparent/struct_multiple_fields.stderr
+++ b/tests/ui/transparent/struct_multiple_fields.stderr
@@ -1,0 +1,11 @@
+error: using #[error(transparent)] in struct `TransparentMany` requires exactly one field
+ --> tests/ui/transparent/struct_multiple_fields.rs:4:1
+  |
+4 | #[error(transparent)]
+  | ^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/transparent/struct_multiple_fields.rs:8:2
+  |
+8 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/ui/transparent/struct_multiple_fields.rs`

--- a/tests/ui/transparent/struct_no_fields.rs
+++ b/tests/ui/transparent/struct_no_fields.rs
@@ -1,0 +1,5 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error(transparent)]
+struct TransparentUnit;

--- a/tests/ui/transparent/struct_no_fields.stderr
+++ b/tests/ui/transparent/struct_no_fields.stderr
@@ -1,0 +1,11 @@
+error: using #[error(transparent)] in struct `TransparentUnit` requires exactly one field
+ --> tests/ui/transparent/struct_no_fields.rs:4:1
+  |
+4 | #[error(transparent)]
+  | ^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/transparent/struct_no_fields.rs:5:24
+  |
+5 | struct TransparentUnit;
+  |                        ^ consider adding a `main` function to `$DIR/tests/ui/transparent/struct_no_fields.rs`


### PR DESCRIPTION
## Summary
- add support for `#[error(transparent)]` in the derive macro with validation of wrapper shape
- delegate `Display`/`source` and `From` generation for transparent errors and update docs
- cover transparent success and failure scenarios with unit tests and trybuild UI cases

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68ca3690e7d0832b8c92ead521e47d24