### PR TITLE
Specify masterror-derive version for packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [dependencies]
-masterror-derive = { path = "masterror-derive" }
+masterror-derive = { path = "masterror-derive", version = "0.1.0" }
 tracing = "0.1"
 
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- declare the `masterror-derive` dependency version so `cargo package` can resolve it when preparing the crate for publishing

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68ca3df9fa94832bab047fd7aa34461b