### PR TITLE
Stop build script from rewriting README during cargo package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +819,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fiat-crypto"
@@ -1447,6 +1463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1536,7 @@ dependencies = [
  "sqlx",
  "telegram-webapp-sdk",
  "teloxide-core",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.23",
@@ -2171,6 +2194,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,6 +2820,19 @@ dependencies = [
  "tokio-util",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ tokio = { version = "1", features = [
 trybuild = "1"
 
 toml = "0.9"
+tempfile = "3"
 
 [build-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/tests/readme_sync.rs
+++ b/tests/readme_sync.rs
@@ -3,6 +3,27 @@ mod readme;
 
 use std::{error::Error, fs, io, path::PathBuf};
 
+use tempfile::tempdir;
+
+const MINIMAL_MANIFEST: &str = r#"[package]
+name = "demo"
+version = "1.2.3"
+rust-version = "1.89"
+edition = "2024"
+
+[features]
+default = []
+
+[package.metadata.masterror.readme]
+feature_order = []
+conversion_lines = []
+feature_snippet_group = 2
+
+[package.metadata.masterror.readme.features]
+"#;
+
+const MINIMAL_TEMPLATE: &str = "# Demo\\n\\nVersion {{CRATE_VERSION}}\\nMSRV {{MSRV}}\\n\\nFeatures\\n{{FEATURE_BULLETS}}\\n\\nSnippet\\n{{FEATURE_SNIPPET}}\\n\\nConversions\\n{{CONVERSION_BULLETS}}\\n";
+
 #[test]
 fn readme_is_in_sync() -> Result<(), Box<dyn Error>> {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -20,4 +41,43 @@ fn readme_is_in_sync() -> Result<(), Box<dyn Error>> {
     }
 
     Ok(())
+}
+
+#[test]
+fn verify_readme_succeeds_when_in_sync() -> Result<(), Box<dyn Error>> {
+    let tmp = tempdir()?;
+    let manifest_path = tmp.path().join("Cargo.toml");
+    let template_path = tmp.path().join("README.template.md");
+    let readme_path = tmp.path().join("README.md");
+
+    fs::write(&manifest_path, MINIMAL_MANIFEST)?;
+    fs::write(&template_path, MINIMAL_TEMPLATE)?;
+    let generated = readme::generate_readme(&manifest_path, &template_path)?;
+    fs::write(&readme_path, generated)?;
+
+    readme::verify_readme(tmp.path()).map_err(|err| io::Error::other(err.to_string()))?;
+    Ok(())
+}
+
+#[test]
+fn verify_readme_detects_out_of_sync() -> Result<(), Box<dyn Error>> {
+    let tmp = tempdir()?;
+    let manifest_path = tmp.path().join("Cargo.toml");
+    let template_path = tmp.path().join("README.template.md");
+    let readme_path = tmp.path().join("README.md");
+
+    fs::write(&manifest_path, MINIMAL_MANIFEST)?;
+    fs::write(&template_path, MINIMAL_TEMPLATE)?;
+    fs::write(&readme_path, "outdated")?;
+
+    match readme::verify_readme(tmp.path()) {
+        Err(readme::ReadmeError::OutOfSync {
+            path
+        }) => {
+            assert_eq!(path, readme_path);
+            Ok(())
+        }
+        Err(err) => Err(io::Error::other(format!("unexpected error: {err}")).into()),
+        Ok(_) => Err(io::Error::other("expected mismatch error").into())
+    }
 }


### PR DESCRIPTION
## Summary
- detect cargo package verification in the build script and only verify the README instead of rewriting it
- extend the README generator with an explicit verification helper and an OutOfSync error
- add focused tests for the new verification path and depend on `tempfile` for fixtures

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo +1.89.0 package --locked --allow-dirty

------
https://chatgpt.com/codex/tasks/task_e_68ca4a6d2940832b9aafec1856dd0419