### PR TITLE
docs: add release checklist to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,18 @@ MSRV = 1.89 (may raise in minor, never in patch).
 </details>
 
 <details>
+  <summary><b>Release checklist</b></summary>
+
+1. `cargo +nightly fmt --`
+1. `cargo clippy -- -D warnings`
+1. `cargo test --all`
+1. `cargo build` (regenerates README.md from the template)
+1. `cargo doc --no-deps`
+1. `cargo package --locked`
+
+</details>
+
+<details>
   <summary><b>Non-goals</b></summary>
 
 - Not a general-purpose error aggregator like `anyhow`

--- a/README.template.md
+++ b/README.template.md
@@ -217,6 +217,18 @@ MSRV = {{MSRV}} (may raise in minor, never in patch).
 </details>
 
 <details>
+  <summary><b>Release checklist</b></summary>
+
+1. `cargo +nightly fmt --`
+1. `cargo clippy -- -D warnings`
+1. `cargo test --all`
+1. `cargo build` (regenerates README.md from the template)
+1. `cargo doc --no-deps`
+1. `cargo package --locked`
+
+</details>
+
+<details>
   <summary><b>Non-goals</b></summary>
 
 - Not a general-purpose error aggregator like `anyhow`


### PR DESCRIPTION
## Summary
- add an explicit release checklist to README.template.md with the steps needed to keep the generated README in sync before publishing
- regenerate README.md from the template so the published file reflects the new checklist and remains build-script compliant

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo test --all
- cargo build --all-targets
- cargo doc --no-deps
- cargo +1.89.0 package --locked

------
https://chatgpt.com/codex/tasks/task_e_68ca4e391b10832bbbd78caefb985a6a