### PR TITLE
Fix README sync verification failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,6 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "toml 0.8.23",
  "toml 0.9.6",
  "tracing",
  "trybuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ tempfile = "3"
 
 [build-dependencies]
 serde = { version = "1", features = ["derive"] }
-toml = "0.8"
+toml = "0.9"
 
 [package.metadata.masterror.readme]
 feature_order = [


### PR DESCRIPTION
## Summary
- align the build-script README generator to use the same `toml` crate version as the tests
- refresh `Cargo.lock` to drop the older `toml 0.8` dependency from the workspace root

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo package --locked --allow-dirty


------
https://chatgpt.com/codex/tasks/task_e_68ca62e9e0e0832b867e0b8dadd86ed1