### PR TITLE
docs: refresh readme generation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # masterror · Framework-agnostic application error types
 
-<!-- This file is used to generate README.md. Edit README.template.md and run `cargo build` to refresh the published README. -->
+<!-- ⚠️ GENERATED FILE: edit README.template.md and run `cargo build` to refresh README.md before publishing. -->
 
 [![Crates.io](https://img.shields.io/crates/v/masterror)](https://crates.io/crates/masterror)
 [![docs.rs](https://img.shields.io/docsrs/masterror)](https://docs.rs/masterror)

--- a/README.template.md
+++ b/README.template.md
@@ -1,6 +1,6 @@
 # masterror · Framework-agnostic application error types
 
-<!-- This file is used to generate README.md. Edit README.template.md and run `cargo build` to refresh the published README. -->
+<!-- ⚠️ GENERATED FILE: edit README.template.md and run `cargo build` to refresh README.md before publishing. -->
 
 [![Crates.io](https://img.shields.io/crates/v/masterror)](https://crates.io/crates/masterror)
 [![docs.rs](https://img.shields.io/docsrs/masterror)](https://docs.rs/masterror)


### PR DESCRIPTION
## Summary
- emphasize in `README.template.md` that the published README is generated
- regenerate `README.md` so the auto-generated file matches the template

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68ca67bfe670832b9f5149446e8d0455