### PR TITLE
Document post-0.4 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,29 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- `#[error(transparent)]` support in the derive macro: validates wrapper shape,
-  delegates `Display`/`source` to the inner error, and works with `#[from]`.
+- Re-exported `thiserror::Error` as `masterror::Error`, making it possible to
+  derive domain errors without an extra dependency. The derive supports
+  `#[from]` conversions, validates `#[error(transparent)]` wrappers, and mirrors
+  `thiserror`'s ergonomics.
+- Added `BrowserConsoleError::context()` for retrieving browser-provided
+  diagnostics when console logging fails.
+
+### Changed
+- README generation now pulls from crate metadata via the build script while
+  staying inert during `cargo package`, preventing dirty worktrees in release
+  workflows.
+
+### Documentation
+- Documented deriving custom errors via `masterror::Error` and expanded the
+  browser console section with context-handling guidance.
+- Added a release checklist and described the automated README sync process.
+
+### Tests
+- Added regression tests covering derive behaviour (including `#[from]` and
+  transparent wrappers) and ensuring the README stays in sync with its
+  template.
+- Added a guard test that enforces the `AppResult<_>` alias over raw
+  `Result<_, AppError>` usages within the crate.
 
 ## [0.4.0] - 2025-09-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ masterror = { version = "0.4.0", default-features = false }
 # ] }
 ~~~
 
+*Unreleased: derive custom errors via `#[derive(Error)]` (`use masterror::Error;`) and inspect browser logging failures with `BrowserConsoleError::context()`.*
 *Since v0.4.0: optional `frontend` feature for WASM/browser console logging.*
 *Since v0.3.0: stable `AppCode` enum and extended `ErrorResponse` with retry/authentication metadata.*
 
@@ -47,8 +48,9 @@ masterror = { version = "0.4.0", default-features = false }
 - **Opt-in integrations.** Zero default features; you enable what you need.
 - **Clean wire contract.** `ErrorResponse { status, code, message, details?, retry?, www_authenticate? }`.
 - **One log at boundary.** Log once with `tracing`.
-- **Less boilerplate.** Built-in conversions, compact prelude,
-  derive macro support for transparent wrappers via `#[error(transparent)]`.
+- **Less boilerplate.** Built-in conversions, compact prelude, and the
+  `masterror::Error` re-export of `thiserror::Error` with `#[from]` /
+  `#[error(transparent)]` support.
 - **Consistent workspace.** Same error surface across crates.
 
 </details>
@@ -103,6 +105,49 @@ fn do_work(flag: bool) -> AppResult<()> {
 </details>
 
 <details>
+  <summary><b>Derive custom errors</b></summary>
+
+~~~rust
+use std::io;
+
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error("I/O failed: {source}")]
+pub struct DomainError {
+    #[from]
+    #[source]
+    source: io::Error,
+}
+
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct WrappedDomainError(
+    #[from]
+    #[source]
+    DomainError
+);
+
+fn load() -> Result<(), DomainError> {
+    Err(io::Error::other("disk offline").into())
+}
+
+let err = load().unwrap_err();
+assert_eq!(err.to_string(), "I/O failed: disk offline");
+
+let wrapped = WrappedDomainError::from(err);
+assert_eq!(wrapped.to_string(), "I/O failed: disk offline");
+~~~
+
+- `use masterror::Error;` re-exports `thiserror::Error`.
+- `#[from]` automatically implements `From<...>` while ensuring wrapper shapes are
+  valid.
+- `#[error(transparent)]` enforces single-field wrappers that forward
+  `Display`/`source` to the inner error.
+
+</details>
+
+<details>
   <summary><b>Error response payload</b></summary>
 
 ~~~rust
@@ -131,7 +176,14 @@ assert_eq!(resp.status, 401);
     assert!(payload.is_object());
 
     #[cfg(target_arch = "wasm32")]
-    err.log_to_browser_console()?;
+    {
+        if let Err(console_err) = err.log_to_browser_console() {
+            eprintln!(
+                "failed to log to browser console: {:?}",
+                console_err.context()
+            );
+        }
+    }
 
     Ok(())
 }
@@ -139,6 +191,8 @@ assert_eq!(resp.status, 401);
 
 - On non-WASM targets `log_to_browser_console` returns
   `BrowserConsoleError::UnsupportedTarget`.
+- `BrowserConsoleError::context()` exposes optional browser diagnostics for
+  logging/telemetry when console logging fails.
 
 </details>
 


### PR DESCRIPTION
## Summary
- capture all post-0.4 additions in the changelog, including derive support, browser console diagnostics, and test coverage
- extend the README template (and regenerate README.md) with the new derive example and browser console guidance
- clarify the `masterror::Error` re-export docs to highlight `#[from]`/`#[error(transparent)]` support

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68ca6cac8a18832b9ab5ddd6a31b6f60