### PR TITLE
docs: emphasize readme regeneration for packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # masterror · Framework-agnostic application error types
 
-<!-- ⚠️ GENERATED FILE: edit README.template.md and run `cargo build` to refresh README.md before publishing. -->
+<!-- ⚠️ GENERATED FILE: edit README.template.md and run `cargo build` to refresh README.md before publishing.
+     CI packaging will fail if README.md is stale. -->
 
 [![Crates.io](https://img.shields.io/crates/v/masterror)](https://crates.io/crates/masterror)
 [![docs.rs](https://img.shields.io/docsrs/masterror)](https://docs.rs/masterror)

--- a/README.template.md
+++ b/README.template.md
@@ -1,6 +1,7 @@
 # masterror · Framework-agnostic application error types
 
-<!-- ⚠️ GENERATED FILE: edit README.template.md and run `cargo build` to refresh README.md before publishing. -->
+<!-- ⚠️ GENERATED FILE: edit README.template.md and run `cargo build` to refresh README.md before publishing.
+     CI packaging will fail if README.md is stale. -->
 
 [![Crates.io](https://img.shields.io/crates/v/masterror)](https://crates.io/crates/masterror)
 [![docs.rs](https://img.shields.io/docsrs/masterror)](https://docs.rs/masterror)


### PR DESCRIPTION
## Summary
- highlight in README.template.md that CI packaging fails when README.md is stale
- regenerate README.md so the committed file matches the updated template

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68ca6c81d290832ba36d94edbd6a8765