### PR TITLE
Prepare documentation for the 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+_No changes yet._
+
+## [0.5.0] - 2025-09-23
+
 ### Added
 - Re-exported `thiserror::Error` as `masterror::Error`, making it possible to
   derive domain errors without an extra dependency. The derive supports
@@ -138,6 +142,8 @@ All notable changes to this project will be documented in this file.
 - **MSRV:** 1.89
 - **No unsafe:** the crate forbids `unsafe`.
 
+[0.5.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.5.0
+[0.4.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.4.0
 [0.3.5]: https://github.com/RAprogramm/masterror/releases/tag/v0.3.5
 [0.3.4]: https://github.com/RAprogramm/masterror/releases/tag/v0.3.4
 [0.3.3]: https://github.com/RAprogramm/masterror/releases/tag/v0.3.3
@@ -146,5 +152,4 @@ All notable changes to this project will be documented in this file.
 [0.3.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.3.0
 [0.2.1]: https://github.com/RAprogramm/masterror/releases/tag/v0.2.1
 [0.2.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.2.0
-[0.4.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.4.0
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ masterror = { version = "0.5.0", default-features = false }
 # ] }
 ~~~
 
-*Unreleased: derive custom errors via `#[derive(Error)]` (`use masterror::Error;`) and inspect browser logging failures with `BrowserConsoleError::context()`.*
+*Since v0.5.0: derive custom errors via `#[derive(Error)]` (`use masterror::Error;`) and inspect browser logging failures with `BrowserConsoleError::context()`.*
 *Since v0.4.0: optional `frontend` feature for WASM/browser console logging.*
 *Since v0.3.0: stable `AppCode` enum and extended `ErrorResponse` with retry/authentication metadata.*
 

--- a/README.template.md
+++ b/README.template.md
@@ -32,7 +32,7 @@ masterror = { version = "{{CRATE_VERSION}}", default-features = false }
 # ] }
 ~~~
 
-*Unreleased: derive custom errors via `#[derive(Error)]` (`use masterror::Error;`) and inspect browser logging failures with `BrowserConsoleError::context()`.*
+*Since v0.5.0: derive custom errors via `#[derive(Error)]` (`use masterror::Error;`) and inspect browser logging failures with `BrowserConsoleError::context()`.*
 *Since v0.4.0: optional `frontend` feature for WASM/browser console logging.*
 *Since v0.3.0: stable `AppCode` enum and extended `ErrorResponse` with retry/authentication metadata.*
 


### PR DESCRIPTION
## Summary
- promote the pending notes into a dated 0.5.0 changelog section and leave the unreleased slate empty
- update the README template to advertise the shipped 0.5.0 features and regenerate the rendered README

## Testing
- cargo +nightly fmt --
- cargo clippy --all-targets -- -D warnings
- cargo test --all
- cargo build --all-targets
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68ca7b6b96e0832b966e750650252cfa