### PR TITLE
Fix CI permissions for reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [ "main" ]
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   ci:
     uses: ./.github/workflows/reusable-ci.yml


### PR DESCRIPTION
## Summary
- grant the CI workflow the write permissions required by the reusable workflow

## Testing
- cargo +nightly fmt --all
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68ca9bfb9574832b931daf9ec2eefe62