### PR TITLE
Remove trailing blank line from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,4 +327,3 @@ MSRV = 1.89 (may raise in minor, never in patch).
 Apache-2.0 OR MIT, at your option.
 
 </details>
-


### PR DESCRIPTION
## Summary
- delete the extra blank line after the closing License `<details>` tag so the generated README matches the template

## Testing
- cargo +nightly fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features --no-fail-fast
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68caa34e53c8832b89d6b277e39c1813