### PR TITLE
Allow #[from] to accept backtrace companions

### DIFF
--- a/masterror-derive/src/from_impl.rs
+++ b/masterror-derive/src/from_impl.rs
@@ -2,7 +2,9 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Error;
 
-use crate::input::{ErrorData, ErrorInput, Field, Fields, StructData, VariantData};
+use crate::input::{
+    ErrorData, ErrorInput, Field, Fields, StructData, VariantData, is_option_type
+};
 
 pub fn expand(input: &ErrorInput) -> Result<Vec<TokenStream>, Error> {
     let mut impls = Vec::new();
@@ -34,19 +36,7 @@ fn struct_from_impl(
     let ty = &field.ty;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    let constructor = match &data.fields {
-        Fields::Named(_) => {
-            let field_ident = field.ident.clone().expect("named field");
-            quote! { Self { #field_ident: value } }
-        }
-        Fields::Unnamed(_) => quote! { Self(value) },
-        Fields::Unit => {
-            return Err(Error::new(
-                field.span,
-                "#[from] is not supported on unit structs"
-            ));
-        }
-    };
+    let constructor = struct_constructor(&data.fields, field)?;
 
     Ok(quote! {
         impl #impl_generics core::convert::From<#ty> for #ident #ty_generics #where_clause {
@@ -67,19 +57,7 @@ fn enum_from_impl(
     let variant_ident = &variant.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    let constructor = match &variant.fields {
-        Fields::Named(_) => {
-            let field_ident = field.ident.clone().expect("named field");
-            quote! { Self::#variant_ident { #field_ident: value } }
-        }
-        Fields::Unnamed(_) => quote! { Self::#variant_ident(value) },
-        Fields::Unit => {
-            return Err(Error::new(
-                field.span,
-                "#[from] is not supported on unit variants"
-            ));
-        }
-    };
+    let constructor = variant_constructor(variant_ident, &variant.fields, field)?;
 
     Ok(quote! {
         impl #impl_generics core::convert::From<#ty> for #ident #ty_generics #where_clause {
@@ -88,4 +66,101 @@ fn enum_from_impl(
             }
         }
     })
+}
+
+fn struct_constructor(fields: &Fields, from_field: &Field) -> Result<TokenStream, Error> {
+    match fields {
+        Fields::Named(named) => {
+            let mut initializers = Vec::new();
+            for field in named {
+                let field_ident = field.ident.clone().expect("named field");
+                let value = field_value_expr(field, from_field)?;
+                initializers.push(quote! { #field_ident: #value });
+            }
+            Ok(quote! { Self { #(#initializers),* } })
+        }
+        Fields::Unnamed(unnamed) => {
+            let mut values = Vec::new();
+            for field in unnamed {
+                values.push(field_value_expr(field, from_field)?);
+            }
+            Ok(quote! { Self(#(#values),*) })
+        }
+        Fields::Unit => Err(Error::new(
+            from_field.span,
+            "#[from] is not supported on unit structs"
+        ))
+    }
+}
+
+fn variant_constructor(
+    variant_ident: &syn::Ident,
+    fields: &Fields,
+    from_field: &Field
+) -> Result<TokenStream, Error> {
+    match fields {
+        Fields::Named(named) => {
+            let mut initializers = Vec::new();
+            for field in named {
+                let field_ident = field.ident.clone().expect("named field");
+                let value = field_value_expr(field, from_field)?;
+                initializers.push(quote! { #field_ident: #value });
+            }
+            Ok(quote! { Self::#variant_ident { #(#initializers),* } })
+        }
+        Fields::Unnamed(unnamed) => {
+            let mut values = Vec::new();
+            for field in unnamed {
+                values.push(field_value_expr(field, from_field)?);
+            }
+            Ok(quote! { Self::#variant_ident(#(#values),*) })
+        }
+        Fields::Unit => Err(Error::new(
+            from_field.span,
+            "#[from] is not supported on unit variants"
+        ))
+    }
+}
+
+fn field_value_expr(field: &Field, from_field: &Field) -> Result<TokenStream, Error> {
+    if field.index == from_field.index {
+        return Ok(quote! { value });
+    }
+
+    if field.attrs.backtrace.is_some() {
+        return Ok(backtrace_initializer(field));
+    }
+
+    if field.attrs.source.is_some() && field.attrs.from.is_none() {
+        return source_initializer(field);
+    }
+
+    Err(Error::new(
+        field.span,
+        "deriving From requires no fields other than source and backtrace"
+    ))
+}
+
+fn source_initializer(field: &Field) -> Result<TokenStream, Error> {
+    if is_option_type(&field.ty) {
+        Ok(quote! { ::core::option::Option::None })
+    } else {
+        Err(Error::new(
+            field.span,
+            "additional #[source] fields used with #[from] must be Option<_>"
+        ))
+    }
+}
+
+fn backtrace_initializer(field: &Field) -> TokenStream {
+    let capture = quote! { ::std::backtrace::Backtrace::capture() };
+    if is_option_type(&field.ty) {
+        quote! {
+            ::core::option::Option::Some(::core::convert::From::from(#capture))
+        }
+    } else {
+        quote! {
+            ::core::convert::From::from(#capture)
+        }
+    }
 }

--- a/tests/ui/from/struct_multiple_fields.rs
+++ b/tests/ui/from/struct_multiple_fields.rs
@@ -5,6 +5,8 @@ use masterror::Error;
 struct BadStruct {
     #[from]
     left: DummyError,
+    #[backtrace]
+    trace: Option<std::backtrace::Backtrace>,
     right: DummyError,
 }
 

--- a/tests/ui/from/variant_multiple_fields.rs
+++ b/tests/ui/from/variant_multiple_fields.rs
@@ -2,9 +2,14 @@ use masterror::Error;
 
 #[derive(Debug, Error)]
 enum BadEnum {
-    #[error("{0} - {1}")]
-    #[from]
-    Two(#[source] DummyError, DummyError),
+    #[error("{source:?} - {extra:?}")]
+    WithExtra {
+        #[from]
+        source: DummyError,
+        #[backtrace]
+        trace: Option<std::backtrace::Backtrace>,
+        extra: DummyError
+    }
 }
 
 #[derive(Debug, Error)]

--- a/tests/ui/from/variant_multiple_fields.stderr
+++ b/tests/ui/from/variant_multiple_fields.stderr
@@ -1,5 +1,5 @@
-error: not expected here; the #[from] attribute belongs on a specific field
- --> tests/ui/from/variant_multiple_fields.rs:6:5
+error: deriving From requires no fields other than source and backtrace
+ --> tests/ui/from/variant_multiple_fields.rs:7:9
   |
-6 |     #[from]
-  |     ^^^^^^^
+7 |         #[from]
+  |         ^^^^^^^


### PR DESCRIPTION
## Summary
- relax the derive input validator to tolerate #[backtrace] and optional #[source] companions when #[from] is present
- teach the generated From impls to populate companion backtrace/source fields so the code compiles
- add positive regression coverage for backtrace companions and update trybuild fixtures for the stricter checks

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68ccb6f9a4c4832b8d6d59f0a722f4ba