### PR TITLE
Support #[backtrace] fields in derived Error impls

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,7 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rustc-check-cfg=cfg(error_generic_member_access)");
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-changed=README.template.md");
     println!("cargo:rerun-if-changed=build/readme.rs");

--- a/tests/error_derive_from_trybuild.rs
+++ b/tests/error_derive_from_trybuild.rs
@@ -11,3 +11,9 @@ fn transparent_attribute_compile_failures() {
     let t = TestCases::new();
     t.compile_fail("tests/ui/transparent/*.rs");
 }
+
+#[test]
+fn backtrace_attribute_compile_failures() {
+    let t = TestCases::new();
+    t.compile_fail("tests/ui/backtrace/*.rs");
+}

--- a/tests/ui/backtrace/duplicate.rs
+++ b/tests/ui/backtrace/duplicate.rs
@@ -1,0 +1,12 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error("duplicate backtrace fields")]
+struct DuplicateBacktrace {
+    #[backtrace]
+    first: std::backtrace::Backtrace,
+    #[backtrace]
+    second: std::backtrace::Backtrace
+}
+
+fn main() {}

--- a/tests/ui/backtrace/duplicate.stderr
+++ b/tests/ui/backtrace/duplicate.stderr
@@ -1,0 +1,5 @@
+error: multiple #[backtrace] fields are not supported
+ --> tests/ui/backtrace/duplicate.rs:8:5
+  |
+8 |     #[backtrace]
+  |     ^^^^^^^^^^^^

--- a/tests/ui/backtrace/invalid_type.rs
+++ b/tests/ui/backtrace/invalid_type.rs
@@ -1,0 +1,10 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error("invalid backtrace field")]
+struct InvalidBacktrace {
+    #[backtrace]
+    trace: String
+}
+
+fn main() {}

--- a/tests/ui/backtrace/invalid_type.stderr
+++ b/tests/ui/backtrace/invalid_type.stderr
@@ -1,0 +1,5 @@
+error: fields with #[backtrace] must be std::backtrace::Backtrace or Option<std::backtrace::Backtrace>
+ --> tests/ui/backtrace/invalid_type.rs:6:5
+  |
+6 |     #[backtrace]
+  |     ^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- teach the Error derive to generate backtrace/provide methods that expose #[backtrace] fields when the standard library feature is available
- validate #[backtrace] usage during input parsing and report duplicates or unsupported field types
- cover the new behaviour with unit tests and trybuild compile-fail cases

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68ccbb6ef4f0832baba7ab1ff6daa7f9