### PR TITLE
chore(ci): enforce cargo deny via reusable action

### DIFF
--- a/.github/actions/cargo-deny/action.yml
+++ b/.github/actions/cargo-deny/action.yml
@@ -1,0 +1,41 @@
+name: "Cargo Deny Check"
+description: "Install and run cargo-deny against the workspace"
+inputs:
+  version:
+    description: "cargo-deny crate version to install"
+    required: false
+    default: "0.18.4"
+  checks:
+    description: "Space-separated list of cargo deny check types (leave empty to run all)"
+    required: false
+    default: "advisories bans licenses sources"
+runs:
+  using: "composite"
+  steps:
+    - name: Ensure cargo-deny
+      shell: bash
+      env:
+        CARGO_DENY_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        current_version=""
+        if command -v cargo-deny >/dev/null 2>&1; then
+          current_version="$(cargo-deny --version | awk '{print $2}')"
+        fi
+        if [ "$current_version" = "$CARGO_DENY_VERSION" ]; then
+          echo "cargo-deny $CARGO_DENY_VERSION already installed"
+          exit 0
+        fi
+        echo "Installing cargo-deny $CARGO_DENY_VERSION"
+        cargo install cargo-deny --locked --force --version "$CARGO_DENY_VERSION"
+    - name: Run cargo-deny
+      shell: bash
+      env:
+        CHECKS: ${{ inputs.checks }}
+      run: |
+        set -euo pipefail
+        if [ -z "${CHECKS// }" ]; then
+          cargo-deny check
+        else
+          cargo-deny check ${CHECKS}
+        fi

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -182,6 +182,9 @@ jobs:
             cargo +${{ steps.msrv.outputs.msrv }} clippy --workspace --all-targets -- -D warnings
           fi
 
+      - name: Cargo deny
+        uses: ./.github/actions/cargo-deny
+
       - name: Tests (MSRV)
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ All notable changes to this project will be documented in this file.
 - `masterror::Error` now uses the in-tree derive, removing the dependency on
   `thiserror` while keeping the same runtime behaviour and diagnostics.
 
+## [0.5.1] - 2025-09-24
+
+### Added
+- Composite GitHub Action (`.github/actions/cargo-deny`) that installs and runs
+  `cargo-deny` checks for reuse across workflows.
+- `cargo deny` step in the reusable CI pipeline to catch advisories, bans,
+  license and source issues automatically.
+- README badges surfacing the Cargo Deny status so consumers can quickly verify
+  supply-chain checks.
+
 ## [0.5.0] - 2025-09-23
 
 ### Added
@@ -150,6 +160,7 @@ All notable changes to this project will be documented in this file.
 - **MSRV:** 1.89
 - **No unsafe:** the crate forbids `unsafe`.
 
+[0.5.1]: https://github.com/RAprogramm/masterror/releases/tag/v0.5.1
 [0.5.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.5.0
 [0.4.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.4.0
 [0.3.5]: https://github.com/RAprogramm/masterror/releases/tag/v0.3.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "actix-web",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.0"
+version = "0.5.1"
 rust-version = "1.90"
 edition = "2024"
 description = "Application error types and response mapping"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ![MSRV](https://img.shields.io/badge/MSRV-1.90-blue)
 ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
 [![CI](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
+[![Cargo Deny](https://img.shields.io/github/actions/workflow/status/RAprogramm/masterror/ci.yml?branch=main&label=Cargo%20Deny)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 
 > 🇷🇺 Читайте README на [русском языке](README.ru.md).
 
@@ -27,9 +28,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.0", default-features = false }
+masterror = { version = "0.5.1", default-features = false }
 # or with features:
-# masterror = { version = "0.5.0", features = [
+# masterror = { version = "0.5.1", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "reqwest", "redis", "validator",
 #   "config", "tokio", "multipart", "teloxide",
@@ -64,10 +65,10 @@ masterror = { version = "0.5.0", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.5.0", default-features = false }
+masterror = { version = "0.5.1", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.5.0", features = [
+# masterror = { version = "0.5.1", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "reqwest", "redis", "validator",
 #   "config", "tokio", "multipart", "teloxide",
@@ -259,13 +260,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.5.0", default-features = false }
+masterror = { version = "0.5.1", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.0", features = [
+masterror = { version = "0.5.1", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -274,7 +275,7 @@ masterror = { version = "0.5.0", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.0", features = [
+masterror = { version = "0.5.1", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,9 +5,10 @@
 [![Crates.io](https://img.shields.io/crates/v/masterror)](https://crates.io/crates/masterror)
 [![docs.rs](https://img.shields.io/docsrs/masterror)](https://docs.rs/masterror)
 [![Downloads](https://img.shields.io/crates/d/masterror)](https://crates.io/crates/masterror)
-![MSRV](https://img.shields.io/badge/MSRV-1.89-blue)
+![MSRV](https://img.shields.io/badge/MSRV-1.90-blue)
 ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
 [![CI](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
+[![Cargo Deny](https://img.shields.io/github/actions/workflow/status/RAprogramm/masterror/ci.yml?branch=main&label=Cargo%20Deny)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 
 Небольшая прагматичная модель ошибок для Rust-сервисов с выраженным API. Основной крейт не зависит от веб-фреймворков, а расширения включаются через фичи. Таксономия ошибок стабильна, соответствие HTTP-кодам консервативно, `unsafe` запрещён.
 
@@ -25,9 +26,9 @@
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.0", default-features = false }
+masterror = { version = "0.5.1", default-features = false }
 # или с нужными интеграциями
-# masterror = { version = "0.5.0", features = [
+# masterror = { version = "0.5.1", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "reqwest", "redis", "validator",
 #   "config", "tokio", "multipart", "teloxide",

--- a/README.template.md
+++ b/README.template.md
@@ -9,6 +9,7 @@
 ![MSRV](https://img.shields.io/badge/MSRV-{{MSRV}}-blue)
 ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
 [![CI](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
+[![Cargo Deny](https://img.shields.io/github/actions/workflow/status/RAprogramm/masterror/ci.yml?branch=main&label=Cargo%20Deny)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 
 > 🇷🇺 Читайте README на [русском языке](README.ru.md).
 


### PR DESCRIPTION
## Summary
- add a composite GitHub Action that installs cargo-deny and hook it into the reusable CI workflow
- surface the cargo-deny job status in the README badges and document the change
- bump the crate to v0.5.1 and record the release in the changelog

## Testing
- cargo +nightly fmt --all
- cargo build --all-targets
- cargo test --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo doc --no-deps

------
https://chatgpt.com/codex/tasks/task_e_68ccc18fb74c832bbd0b548ee502f9a3