### PR TITLE
Configure cargo-deny licensing and bump to v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
 - `masterror::Error` now uses the in-tree derive, removing the dependency on
   `thiserror` while keeping the same runtime behaviour and diagnostics.
 
+## [0.5.2] - 2025-09-25
+
+### Fixed
+- Added a workspace `deny.toml` allow-list for MIT, Apache-2.0 and Unicode-3.0
+  licenses so `cargo deny` accepts existing dependencies.
+- Declared SPDX license expressions for the internal `masterror-derive` and
+  `masterror-template` crates to avoid unlicensed warnings.
+
 ## [0.5.1] - 2025-09-24
 
 ### Changed
@@ -169,6 +177,7 @@ All notable changes to this project will be documented in this file.
 - **MSRV:** 1.89
 - **No unsafe:** the crate forbids `unsafe`.
 
+[0.5.2]: https://github.com/RAprogramm/masterror/releases/tag/v0.5.2
 [0.5.1]: https://github.com/RAprogramm/masterror/releases/tag/v0.5.1
 [0.5.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.5.0
 [0.4.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "actix-web",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.1"
+version = "0.5.2"
 rust-version = "1.90"
 edition = "2024"
 description = "Application error types and response mapping"

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.1", default-features = false }
+masterror = { version = "0.5.2", default-features = false }
 # or with features:
-# masterror = { version = "0.5.1", features = [
+# masterror = { version = "0.5.2", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "reqwest", "redis", "validator",
 #   "config", "tokio", "multipart", "teloxide",
@@ -66,10 +66,10 @@ masterror = { version = "0.5.1", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.5.1", default-features = false }
+masterror = { version = "0.5.2", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.5.1", features = [
+# masterror = { version = "0.5.2", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "reqwest", "redis", "validator",
 #   "config", "tokio", "multipart", "teloxide",
@@ -261,13 +261,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.5.1", default-features = false }
+masterror = { version = "0.5.2", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.1", features = [
+masterror = { version = "0.5.2", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -276,7 +276,7 @@ masterror = { version = "0.5.1", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.1", features = [
+masterror = { version = "0.5.2", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/README.ru.md
+++ b/README.ru.md
@@ -27,9 +27,9 @@
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.1", default-features = false }
+masterror = { version = "0.5.2", default-features = false }
 # или с нужными интеграциями
-# masterror = { version = "0.5.1", features = [
+# masterror = { version = "0.5.2", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "reqwest", "redis", "validator",
 #   "config", "tokio", "multipart", "teloxide",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,27 @@
+[advisories]
+ignore = []
+git-fetch-with-cli = true
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+]
+confidence-threshold = 0.8
+
+[[licenses.exceptions]]
+crate = "unicode-ident"
+allow = ["Apache-2.0", "MIT", "Unicode-3.0"]
+
+[licenses.private]
+ignore = false
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = []
+

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "masterror-derive"
 rust-version = "1.90"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [lib]
 proc-macro = true
@@ -11,4 +12,4 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-masterror-template = { path = "../masterror-template" }
+masterror-template = { path = "../masterror-template", version = "0.1" }

--- a/masterror-template/Cargo.toml
+++ b/masterror-template/Cargo.toml
@@ -3,6 +3,7 @@ name = "masterror-template"
 version = "0.1.0"
 rust-version = "1.90"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
## Summary
- add a workspace deny.toml that allows MIT/Apache/Unicode licenses and fetches advisories via the git CLI
- declare SPDX licenses for the internal crates and pin the masterror-template path dependency version
- bump the crate to v0.5.2 with README and changelog updates and refresh Cargo.lock

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 clippy --all-targets --all-features -- -D warnings
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit


------
https://chatgpt.com/codex/tasks/task_e_68ccc6ba1818832b8c91dff803f0dcfb