### PR TITLE
Add extended template formatter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
   `#[error("...")]` strings and a formatter hook for future custom derives.
 - Internal `masterror-derive` crate powering the native `masterror::Error`
   derive macro.
+- Template placeholders now accept the same formatter traits as `thiserror`
+  (`:?`, `:x`, `:X`, `:p`, `:b`, `:o`, `:e`, `:E`) so existing derives keep
+  compiling when hexadecimal, binary, pointer or exponential formatting is
+  requested.
 
 ### Changed
 - `masterror::Error` now uses the in-tree derive, removing the dependency on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "actix-web",
  "axum",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "masterror-template",
  "proc-macro2",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-template"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "matchit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.2"
+version = "0.5.3"
 rust-version = "1.90"
 edition = "2024"
 description = "Application error types and response mapping"
@@ -35,8 +35,8 @@ turnkey = []
 
 openapi = ["dep:utoipa"]
 [workspace.dependencies]
-masterror-derive = { version = "0.1", path = "masterror-derive" }
-masterror-template = { version = "0.1", path = "masterror-template" }
+masterror-derive = { version = "0.1.1", path = "masterror-derive" }
+masterror-template = { version = "0.1.1", path = "masterror-template" }
 
 [dependencies]
 # masterror-derive = { path = "masterror-derive" }

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.2", default-features = false }
+masterror = { version = "0.5.3", default-features = false }
 # or with features:
-# masterror = { version = "0.5.2", features = [
+# masterror = { version = "0.5.3", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "reqwest", "redis", "validator",
 #   "config", "tokio", "multipart", "teloxide",
@@ -66,10 +66,10 @@ masterror = { version = "0.5.2", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.5.2", default-features = false }
+masterror = { version = "0.5.3", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.5.2", features = [
+# masterror = { version = "0.5.3", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "reqwest", "redis", "validator",
 #   "config", "tokio", "multipart", "teloxide",
@@ -261,13 +261,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.5.2", default-features = false }
+masterror = { version = "0.5.3", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.2", features = [
+masterror = { version = "0.5.3", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -276,7 +276,7 @@ masterror = { version = "0.5.2", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.2", features = [
+masterror = { version = "0.5.3", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
@@ -12,4 +12,4 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-masterror-template = { path = "../masterror-template", version = "0.1" }
+masterror-template = { path = "../masterror-template", version = "0.1.1" }

--- a/masterror-template/Cargo.toml
+++ b/masterror-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror-template"
-version = "0.1.0"
+version = "0.1.1"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/masterror-template/src/template/parser.rs
+++ b/masterror-template/src/template/parser.rs
@@ -147,21 +147,15 @@ fn split_placeholder<'a>(
 
     let formatter = match parts.next().map(str::trim) {
         None => TemplateFormatter::Display,
-        Some("?") => TemplateFormatter::Debug {
-            alternate: false
-        },
-        Some("#?") => TemplateFormatter::Debug {
-            alternate: true
-        },
         Some("") => {
             return Err(TemplateError::InvalidFormatter {
                 span
             });
         }
-        Some(_) => {
-            return Err(TemplateError::InvalidFormatter {
+        Some(spec) => {
+            TemplateFormatter::from_format_spec(spec).ok_or(TemplateError::InvalidFormatter {
                 span
-            });
+            })?
         }
     };
 

--- a/tests/error_derive.rs
+++ b/tests/error_derive.rs
@@ -150,6 +150,18 @@ enum EnumWithBacktrace {
     Unit
 }
 
+#[derive(Debug, Error)]
+#[error(
+    "x={value:x} X={value:X} #x={value:#x} #X={value:#X} b={value:b} #b={value:#b} \
+     o={value:o} #o={value:#o} e={float:e} #e={float:#e} E={float:E} #E={float:#E} \
+     p={ptr:p} #p={ptr:#p}"
+)]
+struct FormatterShowcase {
+    value: u32,
+    float: f64,
+    ptr:   *const u32
+}
+
 #[cfg(error_generic_member_access)]
 fn assert_backtrace_interfaces<E>(error: &E, expected: &std::backtrace::Backtrace)
 where
@@ -347,4 +359,26 @@ fn enum_backtrace_field_is_returned() {
     {
         assert!(std::error::Error::backtrace(&unit).is_none());
     }
+}
+
+#[test]
+fn supports_extended_formatters() {
+    let value = 0x5A5Au32;
+    let float = 1234.5_f64;
+    let ptr = core::ptr::null::<u32>();
+
+    let err = FormatterShowcase {
+        value,
+        float,
+        ptr
+    };
+
+    let expected = format!(
+        "x={value:x} X={value:X} #x={value:#x} #X={value:#X} b={value:b} #b={value:#b} \
+         o={value:o} #o={value:#o} e={float:e} #e={float:#e} E={float:E} #E={float:#E} \
+         p={ptr:p} #p={ptr:#p}"
+    );
+
+    assert_eq!(err.to_string(), expected);
+    assert!(StdError::source(&err).is_none());
 }


### PR DESCRIPTION
## Summary
- add template formatter variants for hex, binary, pointer and exponential rendering
- extend the template parser, derive backend and tests to exercise the richer formatter set
- bump crate versions/docs to 0.5.3/0.1.1 so downstream manifests stay in sync

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68ccd3dbb7d0832b87ff220e11a9bf8e