### PR TITLE
Align derive placeholder formatting with TemplateFormatter variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ All notable changes to this project will be documented in this file.
 - `masterror::Error` now uses the in-tree derive, removing the dependency on
   `thiserror` while keeping the same runtime behaviour and diagnostics.
 
+## [0.5.5] - 2025-09-27
+
+### Fixed
+- Derive formatter generation now matches on every `TemplateFormatter`
+  variant and calls the corresponding `::core::fmt` trait (including the
+  default `Display` path), mirroring `thiserror`'s placeholder handling.
+
 ## [0.5.4] - 2025-09-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "actix-web",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.4"
+version = "0.5.5"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,7 +49,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.1.2", path = "masterror-derive" }
+masterror-derive = { version = "0.1.3", path = "masterror-derive" }
 masterror-template = { version = "0.1.2", path = "masterror-template" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.4", default-features = false }
+masterror = { version = "0.5.5", default-features = false }
 # or with features:
-# masterror = { version = "0.5.4", features = [
+# masterror = { version = "0.5.5", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.5.4", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.5.4", default-features = false }
+masterror = { version = "0.5.5", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.5.4", features = [
+# masterror = { version = "0.5.5", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -262,13 +262,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.5.4", default-features = false }
+masterror = { version = "0.5.5", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.4", features = [
+masterror = { version = "0.5.5", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -277,7 +277,7 @@ masterror = { version = "0.5.4", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.4", features = [
+masterror = { version = "0.5.5", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"


### PR DESCRIPTION
## Summary
- update the derive formatter generation to match on every `TemplateFormatter` variant and invoke the corresponding `::core::fmt` trait or alternate formatting helper
- extract helper functions to keep the generated tokens clear while preserving pointer semantics and the default display path
- bump crate versions to 0.5.5/0.1.3, refresh the README dependency snippets and document the change in the changelog

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68cce3e90278832b85aa0850144c3314