### PR TITLE
Infer default source/backtrace fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 ### Added
 - _Nothing yet._
 
+## [0.5.8] - 2025-09-30
+
+### Changed
+- `masterror::Error` now infers sources named `source` and backtrace fields of
+  type `std::backtrace::Backtrace`/`Option<std::backtrace::Backtrace>` even
+  without explicit attributes, matching `thiserror`'s ergonomics.
+
+### Tests
+- Expanded derive tests to cover implicit `source`/`backtrace` detection across
+  structs and enums.
+
 ## [0.5.7] - 2025-09-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "actix-web",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.7"
+version = "0.5.8"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,7 +49,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.1.3", path = "masterror-derive" }
+masterror-derive = { version = "0.1.4", path = "masterror-derive" }
 masterror-template = { version = "0.1.2", path = "masterror-template" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.7", default-features = false }
+masterror = { version = "0.5.8", default-features = false }
 # or with features:
-# masterror = { version = "0.5.7", features = [
+# masterror = { version = "0.5.8", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.5.7", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.5.7", default-features = false }
+masterror = { version = "0.5.8", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.5.7", features = [
+# masterror = { version = "0.5.8", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -342,13 +342,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.5.7", default-features = false }
+masterror = { version = "0.5.8", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.7", features = [
+masterror = { version = "0.5.8", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -357,7 +357,7 @@ masterror = { version = "0.5.7", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.7", features = [
+masterror = { version = "0.5.8", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/masterror-derive/src/error_trait.rs
+++ b/masterror-derive/src/error_trait.rs
@@ -82,7 +82,7 @@ fn struct_source_body(fields: &Fields, display: &DisplaySpec) -> TokenStream {
             }
         }
         DisplaySpec::Template(_) => {
-            if let Some(field) = fields.iter().find(|field| field.attrs.source.is_some()) {
+            if let Some(field) = fields.iter().find(|field| field.attrs.has_source()) {
                 let member = &field.member;
                 field_source_expr(quote!(self.#member), quote!(&self.#member), &field.ty)
             } else {
@@ -135,10 +135,7 @@ fn variant_transparent_source(variant: &VariantData) -> TokenStream {
 
 fn variant_template_source(variant: &VariantData) -> TokenStream {
     let variant_ident = &variant.ident;
-    let source_field = variant
-        .fields
-        .iter()
-        .find(|field| field.attrs.source.is_some());
+    let source_field = variant.fields.iter().find(|field| field.attrs.has_source());
 
     match (&variant.fields, source_field) {
         (Fields::Unit, _) => quote! { Self::#variant_ident => None },

--- a/masterror-derive/src/from_impl.rs
+++ b/masterror-derive/src/from_impl.rs
@@ -127,11 +127,11 @@ fn field_value_expr(field: &Field, from_field: &Field) -> Result<TokenStream, Er
         return Ok(quote! { value });
     }
 
-    if field.attrs.backtrace.is_some() {
+    if field.attrs.has_backtrace() {
         return Ok(backtrace_initializer(field));
     }
 
-    if field.attrs.source.is_some() && field.attrs.from.is_none() {
+    if field.attrs.has_source() && field.attrs.from.is_none() {
         return source_initializer(field);
     }
 


### PR DESCRIPTION
## Summary
- infer `FieldAttrs` metadata for unannotated `source` and `Backtrace` members so the derive matches `thiserror`
- update code generation to rely on the new `has_source`/`has_backtrace` flags instead of raw attributes
- extend derive tests for structs and enums without explicit `#[source]` / `#[backtrace]`
- bump crate versions to 0.5.8 / 0.1.4, update README and changelog entries

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo +1.90.0 audit
- cargo +1.90.0 deny check

------
https://chatgpt.com/codex/tasks/task_e_68ccf855ef10832baf1cd8aee6264f3f