### PR TITLE
Add TemplateFormatterKind for template formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file.
 ### Added
 - _Nothing yet._
 
+## [0.5.9] - 2025-10-01
+
+### Added
+- `TemplateFormatterKind` enumerating the formatter traits supported by
+  `#[error("...")]`, plus `TemplateFormatter::from_kind`/`kind()` helpers for
+  constructing and inspecting placeholders programmatically.
+
+### Changed
+- Formatter parsing now routes through `TemplateFormatterKind`, ensuring lookup
+  tables, `is_alternate` handling and downstream derives share the same
+  canonical representation.
+
+### Documentation
+- Documented `TemplateFormatterKind` usage and the new inspection helpers
+  across README variants.
+
 ## [0.5.8] - 2025-09-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "actix-web",
  "axum",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-template"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "matchit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.8"
+version = "0.5.9"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -50,7 +50,7 @@ openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
 masterror-derive = { version = "0.1.4", path = "masterror-derive" }
-masterror-template = { version = "0.1.2", path = "masterror-template" }
+masterror-template = { version = "0.1.3", path = "masterror-template" }
 
 [dependencies]
 masterror-derive = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.8", default-features = false }
+masterror = { version = "0.5.9", default-features = false }
 # or with features:
-# masterror = { version = "0.5.8", features = [
+# masterror = { version = "0.5.9", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.5.8", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.5.8", default-features = false }
+masterror = { version = "0.5.9", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.5.8", features = [
+# masterror = { version = "0.5.9", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -155,6 +155,9 @@ assert_eq!(wrapped.to_string(), "I/O failed: disk offline");
 - `TemplateFormatter` mirrors `thiserror`'s formatter detection so existing
   derives that relied on hexadecimal, pointer or exponential renderers keep
   compiling.
+- `TemplateFormatterKind` exposes the formatter trait requested by a
+  placeholder, making it easy to branch on the requested rendering behaviour
+  without manually matching every enum variant.
 
 #### Formatter traits
 
@@ -211,7 +214,9 @@ assert!(rendered.contains("upper=1.5625E-1"));
 ~~~
 
 ~~~rust
-use masterror::error::template::{ErrorTemplate, TemplateFormatter};
+use masterror::error::template::{
+    ErrorTemplate, TemplateFormatter, TemplateFormatterKind
+};
 
 let template = ErrorTemplate::parse("{code:#x} → {payload:?}").expect("parse");
 let mut placeholders = template.placeholders();
@@ -221,6 +226,8 @@ assert!(matches!(
     code.formatter(),
     TemplateFormatter::LowerHex { alternate: true }
 ));
+assert_eq!(code.formatter().kind(), TemplateFormatterKind::LowerHex);
+assert!(code.formatter().is_alternate());
 
 let payload = placeholders.next().expect("payload placeholder");
 assert_eq!(
@@ -342,13 +349,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.5.8", default-features = false }
+masterror = { version = "0.5.9", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.8", features = [
+masterror = { version = "0.5.9", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -357,7 +364,7 @@ masterror = { version = "0.5.8", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.8", features = [
+masterror = { version = "0.5.9", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/README.ru.md
+++ b/README.ru.md
@@ -136,10 +136,13 @@ assert!(rendered.contains("upper=1.5625E-1"));
 ~~~
 
 `masterror::error::template::ErrorTemplate` позволяет разобрать шаблон и
-программно проверить запрошенные форматтеры:
+программно проверить запрошенные форматтеры; перечисление
+`TemplateFormatterKind` возвращает название трейта для каждого плейсхолдера:
 
 ~~~rust
-use masterror::error::template::{ErrorTemplate, TemplateFormatter};
+use masterror::error::template::{
+    ErrorTemplate, TemplateFormatter, TemplateFormatterKind
+};
 
 let template = ErrorTemplate::parse("{code:#x} → {payload:?}").expect("parse");
 let mut placeholders = template.placeholders();
@@ -149,6 +152,8 @@ assert!(matches!(
     code.formatter(),
     TemplateFormatter::LowerHex { alternate: true }
 ));
+assert_eq!(code.formatter().kind(), TemplateFormatterKind::LowerHex);
+assert!(code.formatter().is_alternate());
 
 let payload = placeholders.next().expect("payload placeholder");
 assert_eq!(

--- a/README.template.md
+++ b/README.template.md
@@ -149,6 +149,9 @@ assert_eq!(wrapped.to_string(), "I/O failed: disk offline");
 - `TemplateFormatter` mirrors `thiserror`'s formatter detection so existing
   derives that relied on hexadecimal, pointer or exponential renderers keep
   compiling.
+- `TemplateFormatterKind` exposes the formatter trait requested by a
+  placeholder, making it easy to branch on the requested rendering behaviour
+  without manually matching every enum variant.
 
 #### Formatter traits
 
@@ -205,7 +208,9 @@ assert!(rendered.contains("upper=1.5625E-1"));
 ~~~
 
 ~~~rust
-use masterror::error::template::{ErrorTemplate, TemplateFormatter};
+use masterror::error::template::{
+    ErrorTemplate, TemplateFormatter, TemplateFormatterKind
+};
 
 let template = ErrorTemplate::parse("{code:#x} → {payload:?}").expect("parse");
 let mut placeholders = template.placeholders();
@@ -215,6 +220,8 @@ assert!(matches!(
     code.formatter(),
     TemplateFormatter::LowerHex { alternate: true }
 ));
+assert_eq!(code.formatter().kind(), TemplateFormatterKind::LowerHex);
+assert!(code.formatter().is_alternate());
 
 let payload = placeholders.next().expect("payload placeholder");
 assert_eq!(

--- a/masterror-template/Cargo.toml
+++ b/masterror-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror-template"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.90"
 edition = "2024"
 repository = "https://github.com/RAprogramm/masterror"


### PR DESCRIPTION
## Summary
- introduce `TemplateFormatterKind` plus `TemplateFormatter::from_kind`/`kind` helpers and reuse the kind-driven parsing path
- cover the new helpers with unit tests and rustdoc examples
- document the inspection workflow in README variants, bump crate versions, and record the changes in the changelog

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check


------
https://chatgpt.com/codex/tasks/task_e_68ccfd6e9570832baf6c754f6b520f97