### PR TITLE
Handle advanced formatter specs in template parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 ### Added
 - _Nothing yet._
 
+## [0.5.10] - 2025-10-02
+
+### Changed
+- Template parser now recognises formatter traits even when alignment, sign or
+  width flags precede the type specifier, constructing the matching
+  `TemplateFormatter` variant and keeping alternate (`#`) detection aligned with
+  `thiserror`.
+
+### Tests
+- Extended parser unit tests to cover complex formatter specifiers and
+  additional malformed cases to guard diagnostic accuracy.
+
 ## [0.5.9] - 2025-10-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "actix-web",
  "axum",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-template"
-version = "0.1.3"
+version = "0.1.4"
 
 [[package]]
 name = "matchit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.9"
+version = "0.5.10"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -50,7 +50,7 @@ openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
 masterror-derive = { version = "0.1.4", path = "masterror-derive" }
-masterror-template = { version = "0.1.3", path = "masterror-template" }
+masterror-template = { version = "0.1.4", path = "masterror-template" }
 
 [dependencies]
 masterror-derive = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.9", default-features = false }
+masterror = { version = "0.5.10", default-features = false }
 # or with features:
-# masterror = { version = "0.5.9", features = [
+# masterror = { version = "0.5.10", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.5.9", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.5.9", default-features = false }
+masterror = { version = "0.5.10", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.5.9", features = [
+# masterror = { version = "0.5.10", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -349,13 +349,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.5.9", default-features = false }
+masterror = { version = "0.5.10", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.9", features = [
+masterror = { version = "0.5.10", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -364,7 +364,7 @@ masterror = { version = "0.5.9", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.9", features = [
+masterror = { version = "0.5.10", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/masterror-template/Cargo.toml
+++ b/masterror-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror-template"
-version = "0.1.3"
+version = "0.1.4"
 rust-version = "1.90"
 edition = "2024"
 repository = "https://github.com/RAprogramm/masterror"

--- a/masterror-template/src/template.rs
+++ b/masterror-template/src/template.rs
@@ -410,21 +410,7 @@ impl TemplateFormatter {
     }
 
     pub(crate) fn parse_specifier(spec: &str) -> Option<Self> {
-        let trimmed = spec.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-
-        let (last_index, ty) = trimmed.char_indices().next_back()?;
-        let prefix = &trimmed[..last_index];
-        let alternate = match prefix {
-            "" => false,
-            "#" => true,
-            _ => return None
-        };
-
-        let kind = TemplateFormatterKind::from_specifier(ty)?;
-        Some(Self::from_kind(kind, alternate))
+        parser::parse_formatter_spec(spec)
     }
 
     /// Returns `true` when alternate formatting (`#`) was requested.


### PR DESCRIPTION
## Summary
- enhance the template parser to detect formatter traits after arbitrary alignment, sign and width flags while rejecting duplicate `#` markers
- centralise specifier parsing through a shared helper and expand parser unit tests to cover complex cases and malformed specs
- bump the workspace to v0.5.10 (template crate v0.1.4) with matching README and changelog updates

## Testing
- `cargo +nightly fmt --`
- `cargo +1.90.0 clippy -- -D warnings`
- `cargo +1.90.0 test --all`
- `cargo +1.90.0 doc --no-deps`
- `cargo deny check`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68cd02940704832ba97e2169e4f49a66