### PR TITLE
Align derive formatter dispatch with TemplateFormatterKind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 ### Added
 - _Nothing yet._
 
+## [0.5.11] - 2025-10-03
+
+### Changed
+- Aligned the derive display generator with `TemplateFormatterKind`, invoking the
+  appropriate `core::fmt` trait for every placeholder variant and preserving the
+  default `Display` path when no formatter is provided, mirroring `thiserror`'s
+  behaviour.
+
 ## [0.5.10] - 2025-10-02
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "actix-web",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.10"
+version = "0.5.11"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,7 +49,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.1.4", path = "masterror-derive" }
+masterror-derive = { version = "0.1.5", path = "masterror-derive" }
 masterror-template = { version = "0.1.4", path = "masterror-template" }
 
 [dependencies]

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/masterror-derive/src/display.rs
+++ b/masterror-derive/src/display.rs
@@ -1,4 +1,4 @@
-use masterror_template::template::TemplateFormatter;
+use masterror_template::template::{TemplateFormatter, TemplateFormatterKind};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use syn::Error;
@@ -337,32 +337,83 @@ fn format_placeholder(
         pointer_value
     } = resolved;
 
-    match formatter {
-        TemplateFormatter::Display => format_with_trait(expr, "Display"),
+    let (kind, alternate) = match formatter {
+        TemplateFormatter::Display => (TemplateFormatterKind::Display, false),
         TemplateFormatter::Debug {
             alternate
-        } => format_with_optional_alternate(expr, "Debug", '?', alternate),
+        } => (TemplateFormatterKind::Debug, alternate),
         TemplateFormatter::LowerHex {
             alternate
-        } => format_with_optional_alternate(expr, "LowerHex", 'x', alternate),
+        } => (TemplateFormatterKind::LowerHex, alternate),
         TemplateFormatter::UpperHex {
             alternate
-        } => format_with_optional_alternate(expr, "UpperHex", 'X', alternate),
+        } => (TemplateFormatterKind::UpperHex, alternate),
         TemplateFormatter::Pointer {
             alternate
-        } => format_pointer(expr, pointer_value, alternate),
+        } => (TemplateFormatterKind::Pointer, alternate),
         TemplateFormatter::Binary {
             alternate
-        } => format_with_optional_alternate(expr, "Binary", 'b', alternate),
+        } => (TemplateFormatterKind::Binary, alternate),
         TemplateFormatter::Octal {
             alternate
-        } => format_with_optional_alternate(expr, "Octal", 'o', alternate),
+        } => (TemplateFormatterKind::Octal, alternate),
         TemplateFormatter::LowerExp {
             alternate
-        } => format_with_optional_alternate(expr, "LowerExp", 'e', alternate),
+        } => (TemplateFormatterKind::LowerExp, alternate),
         TemplateFormatter::UpperExp {
             alternate
-        } => format_with_optional_alternate(expr, "UpperExp", 'E', alternate)
+        } => (TemplateFormatterKind::UpperExp, alternate)
+    };
+
+    format_with_formatter_kind(expr, pointer_value, kind, alternate)
+}
+
+fn format_with_formatter_kind(
+    expr: TokenStream,
+    pointer_value: bool,
+    kind: TemplateFormatterKind,
+    alternate: bool
+) -> TokenStream {
+    let trait_name = formatter_trait_name(kind);
+    match kind {
+        TemplateFormatterKind::Display => format_with_trait(expr, trait_name),
+        TemplateFormatterKind::Pointer => {
+            format_pointer(expr, pointer_value, alternate, trait_name)
+        }
+        _ => {
+            if let Some(specifier) = formatter_specifier(kind) {
+                format_with_optional_alternate(expr, trait_name, specifier, alternate)
+            } else {
+                format_with_trait(expr, trait_name)
+            }
+        }
+    }
+}
+
+fn formatter_trait_name(kind: TemplateFormatterKind) -> &'static str {
+    match kind {
+        TemplateFormatterKind::Display => "Display",
+        TemplateFormatterKind::Debug => "Debug",
+        TemplateFormatterKind::LowerHex => "LowerHex",
+        TemplateFormatterKind::UpperHex => "UpperHex",
+        TemplateFormatterKind::Pointer => "Pointer",
+        TemplateFormatterKind::Binary => "Binary",
+        TemplateFormatterKind::Octal => "Octal",
+        TemplateFormatterKind::LowerExp => "LowerExp",
+        TemplateFormatterKind::UpperExp => "UpperExp"
+    }
+}
+
+fn formatter_specifier(kind: TemplateFormatterKind) -> Option<char> {
+    match kind {
+        TemplateFormatterKind::Display | TemplateFormatterKind::Pointer => None,
+        TemplateFormatterKind::Debug => Some('?'),
+        TemplateFormatterKind::LowerHex => Some('x'),
+        TemplateFormatterKind::UpperHex => Some('X'),
+        TemplateFormatterKind::Binary => Some('b'),
+        TemplateFormatterKind::Octal => Some('o'),
+        TemplateFormatterKind::LowerExp => Some('e'),
+        TemplateFormatterKind::UpperExp => Some('E')
     }
 }
 
@@ -393,16 +444,22 @@ fn format_with_alternate(expr: TokenStream, specifier: char) -> TokenStream {
     }
 }
 
-fn format_pointer(expr: TokenStream, pointer_value: bool, alternate: bool) -> TokenStream {
+fn format_pointer(
+    expr: TokenStream,
+    pointer_value: bool,
+    alternate: bool,
+    trait_name: &str
+) -> TokenStream {
     if alternate {
         format_with_alternate(expr, 'p')
     } else if pointer_value {
+        let trait_ident = format_ident!("{}", trait_name);
         quote! {{
             let value = #expr;
-            ::core::fmt::Pointer::fmt(&value, f)?;
+            ::core::fmt::#trait_ident::fmt(&value, f)?;
         }}
     } else {
-        format_with_trait(expr, "Pointer")
+        format_with_trait(expr, trait_name)
     }
 }
 


### PR DESCRIPTION
## Summary
- align the derive display placeholder generation with `TemplateFormatterKind`, dispatching to the correct `core::fmt` trait for every formatter variant and handling pointer placeholders via a shared helper
- add formatter trait/specifier helpers to keep the generated tokens concise while maintaining the default `Display` path
- bump the crate versions to `masterror` 0.5.11 / `masterror-derive` 0.1.5 and document the change in the changelog

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo +1.90.0 audit
- cargo +1.90.0 deny check

------
https://chatgpt.com/codex/tasks/task_e_68cd08c3b984832bb799ff312547b505