### PR TITLE
chore: prepare 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file.
 ### Added
 - _Nothing yet._
 
+## [0.6.0] - 2025-10-06
+
+### Added
+- Enabled the derive and template parser to understand the new formatter
+  specifier, keeping runtime rendering and compile-time diagnostics aligned with
+  `thiserror` while exposing the helper through `TemplateFormatterKind`.
+
+### Tests
+- Expanded the runtime formatter assertions and `trybuild` fixtures to cover the
+  new formatter branch, guarding both successful usage and descriptive error
+  messages.
+
+### Documentation
+- Documented the formatter addition across README variants and crate docs,
+  including updates to the formatter reference table and usage guidance.
+
 ## [0.5.13] - 2025-10-05
 
 ### Documentation
@@ -283,6 +299,7 @@ All notable changes to this project will be documented in this file.
 - **MSRV:** 1.89
 - **No unsafe:** the crate forbids `unsafe`.
 
+[0.6.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.6.0
 [0.5.2]: https://github.com/RAprogramm/masterror/releases/tag/v0.5.2
 [0.5.1]: https://github.com/RAprogramm/masterror/releases/tag/v0.5.1
 [0.5.0]: https://github.com/RAprogramm/masterror/releases/tag/v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "actix-web",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.13"
+version = "0.6.0"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.13", default-features = false }
+masterror = { version = "0.6.0", default-features = false }
 # or with features:
-# masterror = { version = "0.5.13", features = [
+# masterror = { version = "0.6.0", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.5.13", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.5.13", default-features = false }
+masterror = { version = "0.6.0", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.5.13", features = [
+# masterror = { version = "0.6.0", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -383,13 +383,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.5.13", default-features = false }
+masterror = { version = "0.6.0", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.13", features = [
+masterror = { version = "0.6.0", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -398,7 +398,7 @@ masterror = { version = "0.5.13", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.13", features = [
+masterror = { version = "0.6.0", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/README.ru.md
+++ b/README.ru.md
@@ -27,9 +27,9 @@
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.13", default-features = false }
+masterror = { version = "0.6.0", default-features = false }
 # или с нужными интеграциями
-# masterror = { version = "0.5.13", features = [
+# masterror = { version = "0.6.0", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",


### PR DESCRIPTION
## Summary
- bump the `masterror` crate version to 0.6.0 and update README installation snippets
- record the formatter support release notes in the changelog with references to the accompanying documentation and tests

## Testing
- cargo fmt --all
- cargo +nightly fmt --all
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68cd28ac2300832ba7be976873251724