### PR TITLE
Prepare display spec scaffolding for format args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 ### Added
 - _Nothing yet._
 
+## [0.5.14] - 2025-10-06
+
+### Added
+- Prepared the derive input structures for future `format_args!` support by
+  introducing display specification variants for templates with arguments and
+  `fmt = <path>` handlers, along with `FormatArgsSpec`/`FormatArg` metadata
+  scaffolding.
+
 ## [0.5.13] - 2025-10-05
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "actix-web",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.13"
+version = "0.5.14"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,7 +49,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.1.5", path = "masterror-derive" }
+masterror-derive = { version = "0.1.6", path = "masterror-derive" }
 masterror-template = { version = "0.1.4", path = "masterror-template" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.13", default-features = false }
+masterror = { version = "0.5.14", default-features = false }
 # or with features:
-# masterror = { version = "0.5.13", features = [
+# masterror = { version = "0.5.14", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.5.13", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.5.13", default-features = false }
+masterror = { version = "0.5.14", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.5.13", features = [
+# masterror = { version = "0.5.14", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -383,13 +383,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.5.13", default-features = false }
+masterror = { version = "0.5.14", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.13", features = [
+masterror = { version = "0.5.14", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -398,7 +398,7 @@ masterror = { version = "0.5.13", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.13", features = [
+masterror = { version = "0.5.14", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/README.ru.md
+++ b/README.ru.md
@@ -27,9 +27,9 @@
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.13", default-features = false }
+masterror = { version = "0.5.14", default-features = false }
 # или с нужными интеграциями
-# masterror = { version = "0.5.13", features = [
+# masterror = { version = "0.5.14", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/masterror-derive/src/error_trait.rs
+++ b/masterror-derive/src/error_trait.rs
@@ -81,7 +81,13 @@ fn struct_source_body(fields: &Fields, display: &DisplaySpec) -> TokenStream {
                 quote! { None }
             }
         }
-        DisplaySpec::Template(_) => {
+        DisplaySpec::Template(_)
+        | DisplaySpec::TemplateWithArgs {
+            ..
+        }
+        | DisplaySpec::FormatterPath {
+            ..
+        } => {
             if let Some(field) = fields.iter().find(|field| field.attrs.has_source()) {
                 let member = &field.member;
                 field_source_expr(quote!(self.#member), quote!(&self.#member), &field.ty)
@@ -97,7 +103,13 @@ fn variant_source_arm(variant: &VariantData) -> TokenStream {
         DisplaySpec::Transparent {
             ..
         } => variant_transparent_source(variant),
-        DisplaySpec::Template(_) => variant_template_source(variant)
+        DisplaySpec::Template(_)
+        | DisplaySpec::TemplateWithArgs {
+            ..
+        }
+        | DisplaySpec::FormatterPath {
+            ..
+        } => variant_template_source(variant)
     }
 }
 


### PR DESCRIPTION
## Summary
- extend the derive input model with `FormatArgsSpec`, `FormatArg` and `FormatBindingKind`, plus new display variants for template arguments and `fmt = <path>`
- update the display generator and error trait expansion to recognise the new display variants while deferring custom formatter support with diagnostics
- bump crate versions to 0.5.14/0.1.6 and refresh the changelog and README snippets for the new release

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68cd3dee0d50832babd7325204790958