### PR TITLE
Parse #[error] format arguments and fmt handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project will be documented in this file.
 ### Added
 - _Nothing yet._
 
+## [0.5.15] - 2025-10-07
+
+### Added
+- Parse `#[error("...")]` attribute arguments into structured `FormatArg`
+  entries, tracking named bindings and positional indices for future
+  `format_args!` integration.
+- Recognise `#[error(fmt = <path>)]` handlers, capturing the formatter path and
+  associated arguments while guarding against duplicate `fmt` specifications.
+
+### Fixed
+- Produce dedicated diagnostics when unsupported combinations are used, such as
+  providing format arguments alongside `#[error(transparent)]`.
+
+### Tests
+- Extend the `trybuild` suite with regression cases covering duplicate `fmt`
+  handlers and transparent attributes that erroneously include arguments.
+
 ## [0.5.14] - 2025-10-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.5.14"
+version = "0.5.15"
 dependencies = [
  "actix-web",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.5.14"
+version = "0.5.15"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,7 +49,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.1.6", path = "masterror-derive" }
+masterror-derive = { version = "0.1.7", path = "masterror-derive" }
 masterror-template = { version = "0.1.4", path = "masterror-template" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.14", default-features = false }
+masterror = { version = "0.5.15", default-features = false }
 # or with features:
-# masterror = { version = "0.5.14", features = [
+# masterror = { version = "0.5.15", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.5.14", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.5.14", default-features = false }
+masterror = { version = "0.5.15", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.5.14", features = [
+# masterror = { version = "0.5.15", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -383,13 +383,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.5.14", default-features = false }
+masterror = { version = "0.5.15", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.14", features = [
+masterror = { version = "0.5.15", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -398,7 +398,7 @@ masterror = { version = "0.5.14", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.5.14", features = [
+masterror = { version = "0.5.15", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/README.ru.md
+++ b/README.ru.md
@@ -27,9 +27,10 @@
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.5.14", default-features = false }
+# минимальное ядро
+masterror = { version = "0.5.15", default-features = false }
 # или с нужными интеграциями
-# masterror = { version = "0.5.14", features = [
+# masterror = { version = "0.5.15", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/tests/ui/formatter/fail/duplicate_fmt.rs
+++ b/tests/ui/formatter/fail/duplicate_fmt.rs
@@ -1,0 +1,14 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error(fmt = crate::format_error, fmt = crate::format_error)]
+struct DuplicateFmt;
+
+fn format_error(
+    _error: &DuplicateFmt,
+    f: &mut core::fmt::Formatter<'_>
+) -> core::fmt::Result {
+    f.write_str("duplicate")
+}
+
+fn main() {}

--- a/tests/ui/formatter/fail/duplicate_fmt.stderr
+++ b/tests/ui/formatter/fail/duplicate_fmt.stderr
@@ -1,0 +1,11 @@
+error: duplicate `fmt` handler specified
+ --> tests/ui/formatter/fail/duplicate_fmt.rs:4:36
+  |
+4 | #[error(fmt = crate::format_error, fmt = crate::format_error)]
+  |                                    ^^^
+
+error: missing #[error(...)] attribute
+ --> tests/ui/formatter/fail/duplicate_fmt.rs:5:8
+  |
+5 | struct DuplicateFmt;
+  |        ^^^^^^^^^^^^

--- a/tests/ui/transparent/arguments_not_supported.rs
+++ b/tests/ui/transparent/arguments_not_supported.rs
@@ -1,0 +1,7 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error(transparent, code = 42)]
+struct TransparentWithArgs(#[from] std::io::Error);
+
+fn main() {}

--- a/tests/ui/transparent/arguments_not_supported.stderr
+++ b/tests/ui/transparent/arguments_not_supported.stderr
@@ -1,0 +1,11 @@
+error: format arguments are not supported with #[error(transparent)]
+ --> tests/ui/transparent/arguments_not_supported.rs:4:20
+  |
+4 | #[error(transparent, code = 42)]
+  |                    ^
+
+error: missing #[error(...)] attribute
+ --> tests/ui/transparent/arguments_not_supported.rs:5:8
+  |
+5 | struct TransparentWithArgs(#[from] std::io::Error);
+  |        ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- allow #[error("…")] to parse trailing format arguments into FormatArg metadata
- recognise #[error(fmt = <path>)] handlers, capturing their path and guarding against duplicate fmt specs
- surface clearer diagnostics when unsupported argument combinations are used and add trybuild coverage
- bump crate versions and update changelog/readme entries

## Testing
- cargo +nightly fmt --
- RUSTUP_TOOLCHAIN=1.90.0 cargo clippy -- -D warnings
- RUSTUP_TOOLCHAIN=1.90.0 cargo build --all-targets
- RUSTUP_TOOLCHAIN=1.90.0 cargo test --all
- RUSTUP_TOOLCHAIN=1.90.0 cargo doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68cd5180b2bc832ba3440e7714561b93