### PR TITLE
Resolve format arguments in derive Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- _Nothing yet._
+- Resolve `#[error("...")]` format arguments when generating `Display`
+  implementations, supporting named bindings, explicit indices and implicit
+  placeholders via a shared argument environment.
+
+### Tests
+- Cover named format argument expressions, implicit placeholder ordering and
+  enum variants using format arguments.
 
 ## [0.6.0] - 2025-10-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "actix-web",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.6.0"
+version = "0.6.1"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,7 +49,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.2.0", path = "masterror-derive" }
+masterror-derive = { version = "0.2.1", path = "masterror-derive" }
 masterror-template = { version = "0.2.0", path = "masterror-template" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.6.0", default-features = false }
+masterror = { version = "0.6.1", default-features = false }
 # or with features:
-# masterror = { version = "0.6.0", features = [
+# masterror = { version = "0.6.1", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.6.0", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.6.0", default-features = false }
+masterror = { version = "0.6.1", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.6.0", features = [
+# masterror = { version = "0.6.1", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -383,13 +383,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.6.0", default-features = false }
+masterror = { version = "0.6.1", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.6.0", features = [
+masterror = { version = "0.6.1", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -398,7 +398,7 @@ masterror = { version = "0.6.0", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.6.0", features = [
+masterror = { version = "0.6.1", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/masterror-derive/src/input.rs
+++ b/masterror-derive/src/input.rs
@@ -529,7 +529,9 @@ fn parse_format_args(input: ParseStream) -> Result<FormatArgsSpec, Error> {
 
     let mut seen_named = HashSet::new();
 
-    for (index, raw) in parsed.into_iter().enumerate() {
+    let mut positional_index = 0usize;
+
+    for raw in parsed {
         match raw {
             RawFormatArg::Named {
                 ident,
@@ -556,6 +558,8 @@ fn parse_format_args(input: ParseStream) -> Result<FormatArgsSpec, Error> {
                 expr,
                 span
             } => {
+                let index = positional_index;
+                positional_index += 1;
                 let tokens = expr.to_token_stream();
                 args.args.push(FormatArg {
                     tokens,


### PR DESCRIPTION
## Summary
- add a `FormatArgumentsEnv` to `masterror-derive` to cache format arguments, emit prelude bindings, and resolve placeholders before falling back to fields
- extend placeholder helpers to honor the environment for structs and variants, keeping implicit indices in order and preserving previous error diagnostics when no argument matches
- normalize positional indices while parsing format args and add regression tests for implicit, explicit, and mixed placeholder usage

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68cde7465378832bb1a1ac5099816cd7