### PR TITLE
Improve template rendering with write! fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.2] - 2025-10-09
+
 ### Added
 - Resolve `#[error("...")]` format arguments when generating `Display`
   implementations, supporting named bindings, explicit indices and implicit
   placeholders via a shared argument environment.
+
+### Changed
+- Detect additional format arguments, implicit placeholders and non-`Display`
+  formatters in `render_template`, delegating complex cases to a single
+  `write!` invocation while retaining the lightweight `f.write_str` path for
+  literal-only templates. The helper that assembles format arguments now keeps
+  positional/implicit bindings ahead of named ones to satisfy the formatting
+  macro contract.
 
 ### Tests
 - Cover named format argument expressions, implicit placeholder ordering and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "actix-web",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.6.1"
+version = "0.6.2"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,7 +49,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.2.1", path = "masterror-derive" }
+masterror-derive = { version = "0.2.2", path = "masterror-derive" }
 masterror-template = { version = "0.2.0", path = "masterror-template" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.6.1", default-features = false }
+masterror = { version = "0.6.2", default-features = false }
 # or with features:
-# masterror = { version = "0.6.1", features = [
+# masterror = { version = "0.6.2", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.6.1", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.6.1", default-features = false }
+masterror = { version = "0.6.2", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.6.1", features = [
+# masterror = { version = "0.6.2", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -383,13 +383,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.6.1", default-features = false }
+masterror = { version = "0.6.2", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.6.1", features = [
+masterror = { version = "0.6.2", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -398,7 +398,7 @@ masterror = { version = "0.6.1", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.6.1", features = [
+masterror = { version = "0.6.2", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"


### PR DESCRIPTION
## Summary
- teach the derive renderer to fall back to a single `write!` call when templates use extra arguments, implicit slots or non-`Display` formatters while keeping the lightweight literal-only path
- introduce helper structures and `build_template_arguments` to collect named, positional and implicit bindings in a macro-friendly order and escape literals for the generated format string
- bump crate versions to 0.6.2/0.2.2 and update the changelog and README snippets to document the new behaviour

## Testing
- `cargo +nightly fmt --`
- `cargo +1.90.0 clippy -- -D warnings`
- `cargo +1.90.0 build --all-targets`
- `cargo +1.90.0 test --all`
- `cargo +1.90.0 doc --no-deps`
- `cargo deny check`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68cdf10756f4832bab4d4d785ab32481