### PR TITLE
Allow backtrace delegation through sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.4] - 2025-10-11
+
+### Added
+- Exposed an internal `provide` shim that mirrors `thiserror`'s
+  `ThiserrorProvide`, enabling derived errors to forward
+  `core::error::Request` values to their sources.
+
+### Changed
+- Allow `#[backtrace]` to be paired with `#[source]`/`#[from]` fields when the
+  field type implements `Error`, while retaining diagnostics for incompatible
+  non-source fields.
+- Track whether backtrace detection is explicit or inferred so generated
+  implementations avoid providing the same backtrace twice when delegating to
+  sources.
+- Update the generated `provide` methods to call `thiserror_provide` on source
+  fields before exposing the stored backtrace, ensuring delegated traces reach
+  callers.
+
+### Tests
+- Added regression tests covering direct and optional sources annotated with
+  `#[backtrace]`, validating delegated backtrace propagation and `None`
+  handling.
+
 ## [0.6.3] - 2025-10-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "actix-web",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.6.3"
+version = "0.6.4"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,7 +49,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.2.3", path = "masterror-derive" }
+masterror-derive = { version = "0.2.4", path = "masterror-derive" }
 masterror-template = { version = "0.2.0", path = "masterror-template" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.6.3", default-features = false }
+masterror = { version = "0.6.4", default-features = false }
 # or with features:
-# masterror = { version = "0.6.3", features = [
+# masterror = { version = "0.6.4", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.6.3", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.6.3", default-features = false }
+masterror = { version = "0.6.4", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.6.3", features = [
+# masterror = { version = "0.6.4", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -383,13 +383,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.6.3", default-features = false }
+masterror = { version = "0.6.4", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.6.3", features = [
+masterror = { version = "0.6.4", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -398,7 +398,7 @@ masterror = { version = "0.6.3", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.6.3", features = [
+masterror = { version = "0.6.4", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,9 @@ mod code;
 mod convert;
 pub mod error;
 mod kind;
+#[cfg(error_generic_member_access)]
+#[doc(hidden)]
+pub mod provide;
 mod response;
 
 #[cfg(feature = "frontend")]

--- a/src/provide.rs
+++ b/src/provide.rs
@@ -1,0 +1,27 @@
+//! Internal helpers for error derives.
+//!
+//! This module is not intended for public consumption. The trait is
+//! documented as hidden and mirrors the shim provided by `thiserror` to allow
+//! derived errors to forward `core::error::Request` values to their sources.
+
+use core::error::{Error, Request};
+
+#[doc(hidden)]
+pub trait ThiserrorProvide: Sealed {
+    fn thiserror_provide<'a>(&'a self, request: &mut Request<'a>);
+}
+
+impl<T> ThiserrorProvide for T
+where
+    T: Error + ?Sized
+{
+    #[inline]
+    fn thiserror_provide<'a>(&'a self, request: &mut Request<'a>) {
+        self.provide(request);
+    }
+}
+
+#[doc(hidden)]
+pub trait Sealed {}
+
+impl<T> Sealed for T where T: Error + ?Sized {}


### PR DESCRIPTION
## Summary
- allow explicit `#[backtrace]` on `#[source]`/`#[from]` fields when the type is an error and record whether the metadata was inferred or explicit to avoid duplicate provisioning
- update generated `Error::provide` bodies to delegate requests to sources via a new internal `ThiserrorProvide` shim before exposing stored backtraces
- expose the gated `provide` module for derived code, extend regression tests, and bump the crate versions/documentation

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68cdfdc130f0832b888edbc0016e0f6d