### PR TITLE
Add trybuild coverage for format argument shorthands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.5] - 2025-10-12
+
+### Added
+- Accepted `.field` and `.0` shorthand expressions in `#[error("...")]` format
+  argument lists, resolving them against struct and variant fields without
+  moving the original values.
+
+### Changed
+- The format argument resolver now tracks whether it operates on a struct or a
+  destructured enum variant, allowing field shorthands to reuse local bindings
+  and honour pointer formatting requirements.
+
+### Tests
+- Added trybuild pass cases covering named, positional and implicit arguments,
+  formatter path handlers and the new field shorthand expressions.
+- Introduced compile-fail fixtures for duplicate argument names, mixing
+  implicit placeholders after explicitly indexed ones and combining
+  `transparent` with `fmt` handlers.
+- Extended the runtime `error_derive` suite with assertions exercising the
+  shorthand field accessors.
+
 ## [0.6.4] - 2025-10-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "actix-web",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.6.4"
+version = "0.6.5"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,7 +49,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.2.4", path = "masterror-derive" }
+masterror-derive = { version = "0.2.5", path = "masterror-derive" }
 masterror-template = { version = "0.2.0", path = "masterror-template" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.6.4", default-features = false }
+masterror = { version = "0.6.5", default-features = false }
 # or with features:
-# masterror = { version = "0.6.4", features = [
+# masterror = { version = "0.6.5", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.6.4", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.6.4", default-features = false }
+masterror = { version = "0.6.5", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.6.4", features = [
+# masterror = { version = "0.6.5", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -383,13 +383,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.6.4", default-features = false }
+masterror = { version = "0.6.5", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.6.4", features = [
+masterror = { version = "0.6.5", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -398,7 +398,7 @@ masterror = { version = "0.6.4", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.6.4", features = [
+masterror = { version = "0.6.5", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/tests/error_derive.rs
+++ b/tests/error_derive.rs
@@ -267,6 +267,16 @@ struct MixedNamedPositionalArgsError {
 }
 
 #[derive(Debug, Error)]
+#[error("{value}", value = .value)]
+struct FieldShortcutError {
+    value: &'static str
+}
+
+#[derive(Debug, Error)]
+#[error("{}, {}", .0, .1)]
+struct TupleShortcutError(&'static str, &'static str);
+
+#[derive(Debug, Error)]
 #[error("{value}")]
 struct DisplayFormatterError {
     value: &'static str
@@ -410,6 +420,20 @@ fn mixed_named_and_positional_indices_resolve() {
         value: "item"
     };
     assert_eq!(err.to_string(), "item::tag");
+}
+
+#[test]
+fn field_shorthand_arguments_use_struct_fields() {
+    let err = FieldShortcutError {
+        value: "shortcut"
+    };
+    assert_eq!(err.to_string(), "shortcut");
+}
+
+#[test]
+fn tuple_shorthand_arguments_resolve_positions() {
+    let err = TupleShortcutError("first", "second");
+    assert_eq!(err.to_string(), "first, second");
 }
 
 #[test]

--- a/tests/ui/formatter/fail/duplicate_fmt.stderr
+++ b/tests/ui/formatter/fail/duplicate_fmt.stderr
@@ -2,4 +2,4 @@ error: duplicate `fmt` handler specified
  --> tests/ui/formatter/fail/duplicate_fmt.rs:4:36
   |
 4 | #[error(fmt = crate::format_error, fmt = crate::format_error)]
-  |                                    ^^^
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/formatter/fail/duplicate_named_arguments.rs
+++ b/tests/ui/formatter/fail/duplicate_named_arguments.rs
@@ -1,0 +1,9 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error("{value}", value = self.value, value = self.value)]
+struct DuplicateNamedArgumentError {
+    value: &'static str,
+}
+
+fn main() {}

--- a/tests/ui/formatter/fail/duplicate_named_arguments.stderr
+++ b/tests/ui/formatter/fail/duplicate_named_arguments.stderr
@@ -1,0 +1,5 @@
+error: duplicate format argument `value`
+ --> tests/ui/formatter/fail/duplicate_named_arguments.rs:4:40
+  |
+4 | #[error("{value}", value = self.value, value = self.value)]
+  |                                        ^^^^^

--- a/tests/ui/formatter/fail/implicit_after_named.rs
+++ b/tests/ui/formatter/fail/implicit_after_named.rs
@@ -1,0 +1,10 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error("{0}: {}", self.first, self.second)]
+struct ImplicitAfterNamedError {
+    first:  &'static str,
+    second: &'static str,
+}
+
+fn main() {}

--- a/tests/ui/formatter/fail/implicit_after_named.stderr
+++ b/tests/ui/formatter/fail/implicit_after_named.stderr
@@ -1,0 +1,10 @@
+error: argument never used
+ --> tests/ui/formatter/fail/implicit_after_named.rs:3:17
+  |
+3 | #[derive(Debug, Error)]
+  |                 ^^^^^
+  |                 |
+  |                 argument never used
+  |                 formatting specifier missing
+  |
+  = note: this error originates in the derive macro `Error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/formatter/fail/transparent_fmt.rs
+++ b/tests/ui/formatter/fail/transparent_fmt.rs
@@ -1,0 +1,11 @@
+use masterror::Error;
+
+fn format_unit(_f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+#[error(transparent, fmt = crate::format_unit)]
+struct TransparentFormatterWrapper(#[from] std::io::Error);
+
+fn main() {}

--- a/tests/ui/formatter/fail/transparent_fmt.stderr
+++ b/tests/ui/formatter/fail/transparent_fmt.stderr
@@ -1,0 +1,5 @@
+error: format arguments are not supported with #[error(transparent)]
+ --> tests/ui/formatter/fail/transparent_fmt.rs:8:20
+  |
+8 | #[error(transparent, fmt = crate::format_unit)]
+  |                    ^

--- a/tests/ui/formatter/fail/unsupported_flag.stderr
+++ b/tests/ui/formatter/fail/unsupported_flag.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..11 uses an unsupported formatter
- --> tests/ui/formatter/fail/unsupported_flag.rs:4:9
+ --> tests/ui/formatter/fail/unsupported_flag.rs:4:10
   |
 4 | #[error("{value:##x}")]
-  |         ^^^^^^^^^^^^^
+  |          ^^^^^^^^^^^

--- a/tests/ui/formatter/fail/unsupported_formatter.stderr
+++ b/tests/ui/formatter/fail/unsupported_formatter.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..9 uses an unsupported formatter
- --> tests/ui/formatter/fail/unsupported_formatter.rs:4:9
+ --> tests/ui/formatter/fail/unsupported_formatter.rs:4:10
   |
 4 | #[error("{value:y}")]
-  |         ^^^^^^^^^^^
+  |          ^^^^^^^^^

--- a/tests/ui/formatter/fail/uppercase_binary.stderr
+++ b/tests/ui/formatter/fail/uppercase_binary.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..9 uses an unsupported formatter
- --> tests/ui/formatter/fail/uppercase_binary.rs:4:9
+ --> tests/ui/formatter/fail/uppercase_binary.rs:4:10
   |
 4 | #[error("{value:B}")]
-  |         ^^^^^^^^^^^
+  |          ^^^^^^^^^

--- a/tests/ui/formatter/fail/uppercase_pointer.stderr
+++ b/tests/ui/formatter/fail/uppercase_pointer.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..9 uses an unsupported formatter
- --> tests/ui/formatter/fail/uppercase_pointer.rs:4:9
+ --> tests/ui/formatter/fail/uppercase_pointer.rs:4:10
   |
 4 | #[error("{value:P}")]
-  |         ^^^^^^^^^^^
+  |          ^^^^^^^^^

--- a/tests/ui/formatter/pass/field_shortcuts.rs
+++ b/tests/ui/formatter/pass/field_shortcuts.rs
@@ -1,0 +1,16 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error("{value}", value = .value)]
+struct FieldShortcut {
+    value: &'static str,
+}
+
+#[derive(Debug, Error)]
+#[error("{}:{}", .0, .1)]
+struct TupleShortcut(&'static str, &'static str);
+
+fn main() {
+    let _ = FieldShortcut { value: "alpha" }.to_string();
+    let _ = TupleShortcut("left", "right").to_string();
+}

--- a/tests/ui/formatter/pass/format_arguments.rs
+++ b/tests/ui/formatter/pass/format_arguments.rs
@@ -1,0 +1,44 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error("{label}::{name}", label = self.label, name = self.name)]
+struct NamedArgumentUsage {
+    label: &'static str,
+    name:  &'static str,
+}
+
+#[derive(Debug, Error)]
+#[error("{1}::{0}", self.first, self.second)]
+struct PositionalArgumentUsage {
+    first:  &'static str,
+    second: &'static str,
+}
+
+#[derive(Debug, Error)]
+#[error("{}, {label}, {}", label = self.label, self.first, self.second)]
+struct MixedImplicitUsage {
+    label:  &'static str,
+    first:  &'static str,
+    second: &'static str,
+}
+
+fn main() {
+    let _ = NamedArgumentUsage {
+        label: "left",
+        name:  "right",
+    }
+    .to_string();
+
+    let _ = PositionalArgumentUsage {
+        first:  "positional-0",
+        second: "positional-1",
+    }
+    .to_string();
+
+    let _ = MixedImplicitUsage {
+        label:  "tag",
+        first:  "one",
+        second: "two",
+    }
+    .to_string();
+}


### PR DESCRIPTION
## Summary
- add parsing support for `.field` and `.0` shorthand format arguments and treat duplicates consistently
- teach the display expansion to resolve struct and variant shorthand bindings while preserving pointer formatting semantics
- extend trybuild/ui suites and runtime tests for the new formatter support, bumping the workspace to v0.6.5 and updating the changelog/readme

## Testing
- `cargo +nightly fmt --`
- `cargo +nightly clippy --all-targets -- -D warnings`
- `cargo +nightly test --all`
- `cargo +nightly doc --no-deps`
- `cargo deny check`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68ce06149408832bb2d9f1a347986dd1