### PR TITLE
Support display-only format specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.0] - 2025-10-21
+
+### Added
+- Preserved the raw format fragment for display-only placeholders, exposing it
+  through `TemplateFormatter::display_spec()`/`format_fragment()` so derived
+  implementations can forward `:>8`, `:.3`, and similar specifiers to
+  `write!`.
+
+### Changed
+- `TemplateFormatter` now owns display specs and `TemplatePlaceholder::formatter`
+  returns a reference to reflect the richer formatter representation.
+
+### Tests
+- Added a trybuild pass case and runtime assertions covering display alignment,
+  precision, and fill specifiers to prevent regressions.
+
+### Documentation
+- Documented the new display formatter support in the README (including the
+  Russian translation) with examples showing how to recover preserved specs.
+
 ## [0.9.0] - 2025-10-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "actix-web",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "masterror-template",
  "proc-macro2",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-template"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "matchit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.9.0"
+version = "0.10.0"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,8 +49,8 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.5.0", path = "masterror-derive" }
-masterror-template = { version = "0.2.0", path = "masterror-template" }
+masterror-derive = { version = "0.6.0", path = "masterror-derive" }
+masterror-template = { version = "0.3.0", path = "masterror-template" }
 
 [dependencies]
 masterror-derive = { workspace = true }

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/masterror-derive/src/template_support.rs
+++ b/masterror-derive/src/template_support.rs
@@ -56,7 +56,7 @@ pub fn parse_display_template(lit: LitStr) -> Result<DisplayTemplate, Error> {
                 segments.push(TemplateSegmentSpec::Placeholder(TemplatePlaceholderSpec {
                     span,
                     identifier,
-                    formatter: placeholder.formatter()
+                    formatter: placeholder.formatter().clone()
                 }));
             }
         }

--- a/masterror-template/Cargo.toml
+++ b/masterror-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror-template"
-version = "0.2.0"
+version = "0.3.0"
 rust-version = "1.90"
 edition = "2024"
 repository = "https://github.com/RAprogramm/masterror"

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,7 +90,7 @@
 //! let payload_formatter = payload.formatter();
 //! assert_eq!(
 //!     payload_formatter,
-//!     TemplateFormatter::Debug {
+//!     &TemplateFormatter::Debug {
 //!         alternate: false
 //!     }
 //! );

--- a/tests/error_derive.rs
+++ b/tests/error_derive.rs
@@ -410,6 +410,24 @@ struct UpperExpFormatterError {
     value: f64
 }
 
+#[derive(Debug, Error)]
+#[error("{value:>8}", value = .value)]
+struct DisplayAlignmentError {
+    value: &'static str
+}
+
+#[derive(Debug, Error)]
+#[error("{value:.3}", value = .value)]
+struct DisplayPrecisionError {
+    value: f64
+}
+
+#[derive(Debug, Error)]
+#[error("{value:*<6}", value = .value)]
+struct DisplayFillError {
+    value: &'static str
+}
+
 #[cfg(error_generic_member_access)]
 fn assert_backtrace_interfaces<E>(error: &E, expected: &std::backtrace::Backtrace)
 where
@@ -1046,4 +1064,22 @@ fn formatter_variants_render_expected_output() {
     let upper_exp_expected = format!("upper={value:E} #upper={value:#E}", value = FLOAT_VALUE);
     assert_eq!(upper_exp.to_string(), upper_exp_expected);
     assert_ne!(format!("{FLOAT_VALUE:e}"), format!("{FLOAT_VALUE:E}"));
+}
+
+#[test]
+fn display_format_specs_match_standard_formatting() {
+    let alignment = DisplayAlignmentError {
+        value: "x"
+    };
+    assert_eq!(alignment.to_string(), format!("{:>8}", "x"));
+
+    let precision = DisplayPrecisionError {
+        value: 123.456_f64
+    };
+    assert_eq!(precision.to_string(), format!("{:.3}", 123.456_f64));
+
+    let fill = DisplayFillError {
+        value: "ab"
+    };
+    assert_eq!(fill.to_string(), format!("{:*<6}", "ab"));
 }

--- a/tests/ui/formatter/pass/display_specs.rs
+++ b/tests/ui/formatter/pass/display_specs.rs
@@ -1,0 +1,21 @@
+use masterror::Error;
+
+#[derive(Debug, Error)]
+#[error("{value:>8}", value = .value)]
+struct Alignment {
+    value: &'static str,
+}
+
+#[derive(Debug, Error)]
+#[error("{value:.3}", value = .value)]
+struct Precision {
+    value: f64,
+}
+
+#[derive(Debug, Error)]
+#[error("{value:*<6}", value = .value)]
+struct Fill {
+    value: &'static str,
+}
+
+fn main() {}


### PR DESCRIPTION
## Summary
- preserve raw display-only format specifiers in `TemplateFormatter` and expose helpers for derived consumers
- update the derive codegen to forward alignment, precision, and fill fragments when invoking `write!`
- document the new formatter behaviour, add regression coverage, and bump crate versions with changelog entry

## Testing
- `cargo +nightly fmt --`
- `cargo +nightly clippy -- -D warnings`
- `cargo +nightly build --all-targets`
- `cargo +nightly test --all`
- `cargo +nightly doc --no-deps`
- `cargo +nightly audit`
- `cargo +nightly deny check`


------
https://chatgpt.com/codex/tasks/task_e_68ce40146c70832bb02d4ae31a299b4d