### PR TITLE
fix(ci): allow cargo package dry run

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[patch.crates-io]
+masterror-derive = { path = "masterror-derive" }
+masterror-template = { path = "masterror-template" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
   end-to-end examples in the derive guide ([README](README.md#structured-telemetry-providers-and-apperror-mappings),
   [README.ru](README.ru.md#%D0%B0%D1%82%D1%80%D0%B8%D0%B1%D1%83%D1%82%D1%8B-provide-%D0%B8-apperror)).
 
+## [0.10.4] - 2025-09-20
+
+### Fixed
+- Ensured `cargo package --locked` passes by switching workspace dependencies on
+  `masterror-derive` / `masterror-template` to registry entries and overriding
+  them locally through `.cargo/config`, keeping CI dry runs green without
+  breaking local development.
+
 ## [0.10.2] - 2025-10-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "actix-web",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.10.3"
+version = "0.10.4"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -11,6 +11,28 @@ documentation = "https://docs.rs/masterror"
 build = "build.rs"
 categories = ["rust-patterns", "web-programming"]
 keywords = ["error", "api", "framework"]
+include = [
+  "Cargo.toml",
+  "Cargo.lock",
+  "build.rs",
+  "src/**",
+  "tests/**",
+  "README.md",
+  "README.ru.md",
+  "README.template.md",
+  "CHANGELOG.md",
+  "LICENSE-APACHE",
+  "LICENSE-MIT",
+  "Makefile.toml",
+  "deny.toml",
+  "idea.md",
+  "target.md",
+  "build/**",
+  "masterror-derive/**",
+  "masterror-template/**",
+  ".cargo/audit.toml",
+  ".cargo/config.toml"
+]
 
 [workspace]
 members = ["masterror-derive", "masterror-template"]
@@ -49,8 +71,8 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.6.0", path = "masterror-derive" }
-masterror-template = { version = "0.3.1", path = "masterror-template" }
+masterror-derive = { version = "0.6.0" }
+masterror-template = { version = "0.3.1" }
 
 [dependencies]
 masterror-derive = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.10.3", default-features = false }
+masterror = { version = "0.10.4", default-features = false }
 # or with features:
-# masterror = { version = "0.10.3", features = [
+# masterror = { version = "0.10.4", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.10.3", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.10.3", default-features = false }
+masterror = { version = "0.10.4", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.10.3", features = [
+# masterror = { version = "0.10.4", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -623,13 +623,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.10.3", default-features = false }
+masterror = { version = "0.10.4", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.10.3", features = [
+masterror = { version = "0.10.4", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -638,7 +638,7 @@ masterror = { version = "0.10.3", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.10.3", features = [
+masterror = { version = "0.10.4", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/README.ru.md
+++ b/README.ru.md
@@ -28,9 +28,9 @@
 ~~~toml
 [dependencies]
 # минимальное ядро
-masterror = { version = "0.10.3", default-features = false }
+masterror = { version = "0.10.4", default-features = false }
 # или с нужными интеграциями
-# masterror = { version = "0.10.3", features = [
+# masterror = { version = "0.10.4", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",


### PR DESCRIPTION
## Summary
- stop using path dependencies for `masterror-derive`/`masterror-template`, rely on their declared versions and override them locally via `.cargo/config`
- whitelist the workspace sources in `include`, add the config to the package payload, and bump the crate version to 0.10.4
- refresh README badges/snippets and CHANGELOG for the new release

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy --workspace --all-targets --all-features -- -D warnings
- cargo +1.90.0 test --workspace --all-features --no-fail-fast
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit --deny warnings

------
https://chatgpt.com/codex/tasks/task_e_68ce8478e99c832bbb42404d39139d0c