### PR TITLE
Fix masterror-derive publish by adding README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.6] - 2025-09-21
+
+### Fixed
+- Added a crate-local README for `masterror-derive` so `cargo publish` passes
+  when crates.io validates the `readme` manifest key.
+
+### Changed
+- Bumped `masterror-derive` to `0.6.2` to capture the packaging fix.
+
+### Documentation
+- Documented the derive macros and supported attributes in
+  `masterror-derive/README.md` for crates.io readers.
+
 ## [0.10.5] - 2025-09-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "actix-web",
  "axum",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.10.5"
+version = "0.10.6"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -71,7 +71,7 @@ turnkey = []
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.6.1" }
+masterror-derive = { version = "0.6.2" }
 masterror-template = { version = "0.3.1" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.10.5", default-features = false }
+masterror = { version = "0.10.6", default-features = false }
 # or with features:
-# masterror = { version = "0.10.5", features = [
+# masterror = { version = "0.10.6", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.10.5", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.10.5", default-features = false }
+masterror = { version = "0.10.6", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.10.5", features = [
+# masterror = { version = "0.10.6", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -623,13 +623,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.10.5", default-features = false }
+masterror = { version = "0.10.6", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.10.5", features = [
+masterror = { version = "0.10.6", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -638,7 +638,7 @@ masterror = { version = "0.10.5", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.10.5", features = [
+masterror = { version = "0.10.6", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/masterror-derive/README.md
+++ b/masterror-derive/README.md
@@ -1,0 +1,68 @@
+# masterror-derive
+
+Procedural macros that power [`masterror`](https://crates.io/crates/masterror)'s
+`#[derive(Error)]`. The derive generates ergonomic `std::error::Error` and
+`Display` implementations together with seamless integration into
+`masterror`'s domain-centric `AppError` type.
+
+> **Tip:** Depend on the `masterror` crate in application code and import the
+> macros from there (`use masterror::Error;`). This standalone crate is
+> published to make `cargo install`/`cargo package` flows happy and to support
+> advanced macro integrations.
+
+## Quick start
+
+```toml
+[dependencies]
+masterror = "0.10"
+```
+
+```rust
+use masterror::{AppError, Error};
+
+#[derive(Error)]
+#[error(display = "failed to parse payload: {source}")]
+#[app_error(kind = "BadRequest")]
+pub struct PayloadInvalid {
+    #[source]
+    pub source: serde_json::Error,
+}
+
+fn parse(input: &str) -> Result<(), AppError> {
+    serde_json::from_str::<serde_json::Value>(input)
+        .map(|_| ())
+        .map_err(PayloadInvalid::from)
+}
+```
+
+The derive implements `Display`, `std::error::Error`, and conversion glue so
+you can return rich `AppError` values with a single `?`.
+
+## Supported attributes
+
+- `#[error(display = ...)]` – formats the error message using captured fields.
+- `#[source]` / `#[from]` – wires source error propagation and conversion.
+- `#[backtrace]` – exposes an optional captured `Backtrace`.
+- `#[app_error(...)]` – configures how the error maps into `AppError`
+  (kind, HTTP status, telemetry).
+- `#[provide(...)]` – attaches structured telemetry providers that surface
+  typed context (IDs, domains, tenant information) through tracing layers.
+
+See the main [`masterror` README](https://github.com/RAprogramm/masterror/blob/HEAD/README.md) for an end-to-end guide and
+advanced examples covering templated display strings, telemetry providers and
+OpenAPI/schema integrations.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0, ([LICENSE-APACHE](https://github.com/RAprogramm/masterror/blob/HEAD/LICENSE-APACHE) or
+  <https://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/RAprogramm/masterror/blob/HEAD/LICENSE-MIT) or <https://opensource.org/licenses/MIT>)
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+


### PR DESCRIPTION
## Summary
- add a crate-local README for `masterror-derive` so `cargo publish` validates the `readme` key
- bump `masterror` to 0.10.6 and `masterror-derive` to 0.6.2, updating the changelog and root README guidance

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68ceaf165738832bb4de189318e21ed7