### PR TITLE
chore: publish template crate before derive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,33 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
 
+      - name: Maybe publish masterror-template
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if cargo metadata --no-deps --format-version=1 \
+             | jq -e '.packages[] | select(.name=="masterror-template" and .source==null)' >/dev/null; then
+            echo "Publishing masterror-template..."
+            n=0
+            until [ $n -ge 5 ]
+            do
+              if cargo +${{ steps.msrv.outputs.msrv }} publish -p masterror-template --locked --token "$CARGO_REGISTRY_TOKEN"; then
+                echo "masterror-template published."
+                break
+              fi
+              n=$((n+1))
+              echo "Retry $n/5 for masterror-template..."
+              sleep $((5*n))
+            done
+          else
+            echo "No local masterror-template found; skipping."
+          fi
+
+      - name: Wait for crates.io index sync (after template)
+        run: sleep 15
+
       - name: Maybe publish masterror-derive
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.8] - 2025-10-25
+
+### Fixed
+- Updated the release workflow to publish `masterror-template` before
+  `masterror-derive`, ensuring crates.io recognises the shared dependency during
+  release automation.
+
 ## [0.10.7] - 2025-10-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "actix-web",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.10.7"
+version = "0.10.8"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.10.7", default-features = false }
+masterror = { version = "0.10.8", default-features = false }
 # or with features:
-# masterror = { version = "0.10.7", features = [
+# masterror = { version = "0.10.8", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.10.7", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.10.7", default-features = false }
+masterror = { version = "0.10.8", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.10.7", features = [
+# masterror = { version = "0.10.8", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -623,13 +623,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.10.7", default-features = false }
+masterror = { version = "0.10.8", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.10.7", features = [
+masterror = { version = "0.10.8", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -638,7 +638,7 @@ masterror = { version = "0.10.7", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.10.7", features = [
+masterror = { version = "0.10.8", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }


### PR DESCRIPTION
## Summary
- ensure the release workflow publishes `masterror-template` before `masterror-derive`, with an index sync pause between the crates
- bump `masterror` to 0.10.8 and update the changelog and README snippets accordingly

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68cf3d978f04832ba7d447c18d645252