### PR TITLE
Document MSRV 1.90 and regenerate README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.9] - 2025-10-26
+
+### Changed
+- Raised the documented MSRV to Rust 1.90 to match the `rust-version`
+  requirement.
+
+### Documentation
+- Regenerated the README from the template so installation snippets reflect the
+  new crate version and MSRV statement.
+
 ## [0.10.8] - 2025-10-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "actix-web",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.10.8"
+version = "0.10.9"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Stable categories, conservative HTTP mapping, no `unsafe`.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.10.8", default-features = false }
+masterror = { version = "0.10.9", default-features = false }
 # or with features:
-# masterror = { version = "0.10.8", features = [
+# masterror = { version = "0.10.9", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -66,10 +66,10 @@ masterror = { version = "0.10.8", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.10.8", default-features = false }
+masterror = { version = "0.10.9", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.10.8", features = [
+# masterror = { version = "0.10.9", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -623,13 +623,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.10.8", default-features = false }
+masterror = { version = "0.10.9", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.10.8", features = [
+masterror = { version = "0.10.9", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -638,7 +638,7 @@ masterror = { version = "0.10.8", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.10.8", features = [
+masterror = { version = "0.10.9", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -709,4 +709,3 @@ MSRV = 1.90 (may raise in minor, never in patch).
 Apache-2.0 OR MIT, at your option.
 
 </details>
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! MSRV is **1.89**. New minor releases may increase MSRV with a changelog
+//! MSRV is **1.90**. New minor releases may increase MSRV with a changelog
 //! note, but never in a patch release.
 //!
 //! # Feature flags

--- a/src/turnkey/classifier.rs
+++ b/src/turnkey/classifier.rs
@@ -106,7 +106,7 @@ fn contains_any_nocase(haystack: &str, needles: &[&str]) -> bool {
 /// Converts ASCII letters to lowercase and leaves other bytes unchanged.
 #[inline]
 const fn ascii_lower(b: u8) -> u8 {
-    // ASCII-only fold without RangeInclusive to keep const-friendly on MSRV 1.89
+    // ASCII-only fold without RangeInclusive to keep const-friendly on MSRV 1.90
     if b >= b'A' && b <= b'Z' { b + 32 } else { b }
 }
 

--- a/tests/readme_sync.rs
+++ b/tests/readme_sync.rs
@@ -8,7 +8,7 @@ use tempfile::tempdir;
 const MINIMAL_MANIFEST: &str = r#"[package]
 name = "demo"
 version = "1.2.3"
-rust-version = "1.89"
+rust-version = "1.90"
 edition = "2024"
 
 [features]


### PR DESCRIPTION
## Summary
- update the crate documentation to state Rust 1.90 as the MSRV and refresh supporting comments/tests
- bump the crate version to 0.10.9 with a changelog entry and regenerate the README from the template

## Testing
- cargo +nightly fmt --
- cargo build --all-targets
- cargo clippy -- -D warnings
- cargo test --all
- cargo doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68cf4d2b6fac832bb98ebfcd6fab5310