### PR TITLE
Expose error kind messages in responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.11.2] - 2025-10-28
+
+### Changed
+- Surfaced the [`AppErrorKind`] display text as the fallback `ErrorResponse`
+  message so clients receive semantic descriptions without providing a custom
+  message.
+
+### Tests
+- Added regression coverage ensuring bare `AppError` kinds map to their
+  corresponding default message.
+
 ## [0.11.1] - 2025-10-27
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "actix-web",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.11.1"
+version = "0.11.2"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ guides, comparisons with `thiserror`/`anyhow`, and troubleshooting recipes.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.11.1", default-features = false }
+masterror = { version = "0.11.2", default-features = false }
 # or with features:
-# masterror = { version = "0.11.1", features = [
+# masterror = { version = "0.11.2", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -73,10 +73,10 @@ masterror = { version = "0.11.1", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.11.1", default-features = false }
+masterror = { version = "0.11.2", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.11.1", features = [
+# masterror = { version = "0.11.2", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -632,13 +632,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.11.1", default-features = false }
+masterror = { version = "0.11.2", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.11.1", features = [
+masterror = { version = "0.11.2", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -647,7 +647,7 @@ masterror = { version = "0.11.1", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.11.1", features = [
+masterror = { version = "0.11.2", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -718,4 +718,3 @@ MSRV = 1.90 (may raise in minor, never in patch).
 Apache-2.0 OR MIT, at your option.
 
 </details>
-

--- a/README.ru.md
+++ b/README.ru.md
@@ -37,9 +37,9 @@
 ~~~toml
 [dependencies]
 # минимальное ядро
-masterror = { version = "0.11.1", default-features = false }
+masterror = { version = "0.11.2", default-features = false }
 # или с нужными интеграциями
-# masterror = { version = "0.11.1", features = [
+# masterror = { version = "0.11.2", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",

--- a/src/response/mapping.rs
+++ b/src/response/mapping.rs
@@ -26,7 +26,7 @@ impl From<AppError> for ErrorResponse {
         let code = AppCode::from(kind);
         let message = match message {
             Some(msg) => msg.into_owned(),
-            None => String::from("An error occurred")
+            None => kind.to_string()
         };
 
         Self {
@@ -48,7 +48,7 @@ impl From<&AppError> for ErrorResponse {
         let message = err
             .message
             .clone()
-            .unwrap_or(Cow::Borrowed("An error occurred"))
+            .unwrap_or_else(|| Cow::Owned(err.kind.to_string()))
             .into_owned();
 
         Self {

--- a/src/response/tests.rs
+++ b/src/response/tests.rs
@@ -144,7 +144,7 @@ fn from_app_error_uses_default_message_when_none() {
     let e: ErrorResponse = (&app).into();
     assert_eq!(e.status, 500);
     assert!(matches!(e.code, AppCode::Internal));
-    assert_eq!(e.message, "An error occurred");
+    assert_eq!(e.message, AppErrorKind::Internal.to_string());
 }
 
 #[test]
@@ -168,7 +168,17 @@ fn from_owned_app_error_defaults_message_when_absent() {
 
     assert_eq!(resp.status, 500);
     assert!(matches!(resp.code, AppCode::Internal));
-    assert_eq!(resp.message, "An error occurred");
+    assert_eq!(resp.message, AppErrorKind::Internal.to_string());
+}
+
+#[test]
+fn from_app_error_bare_uses_kind_display_as_message() {
+    let app = AppError::bare(AppErrorKind::Timeout);
+    let resp: ErrorResponse = app.into();
+
+    assert_eq!(resp.status, 504);
+    assert!(matches!(resp.code, AppCode::Timeout));
+    assert_eq!(resp.message, AppErrorKind::Timeout.to_string());
 }
 
 // --- Display formatting --------------------------------------------------


### PR DESCRIPTION
## Summary
- fall back to each `AppErrorKind`'s Display text when building an `ErrorResponse`
- align response mapping tests with the richer defaults and cover timeout fallbacks
- bump crate metadata and docs to version 0.11.2 with changelog entry

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo test --all
- cargo build --all-targets
- cargo doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68d1ea865b44832b94cab6ed1840af21