### PR TITLE
Add ResultExt context builder and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.12.1] - 2025-10-30
+
+### Added
+- Introduced the `Context` builder for enriching error conversions with
+  metadata, caller tracking, and redaction hints via `ResultExt::ctx`.
+- Implemented the `ResultExt` trait to wrap fallible operations into
+  `masterror::Error` without extra allocations while merging context fields.
+
+### Documentation
+- Added rustdoc examples showcasing `Context` chaining and the new
+  `ResultExt` helper.
+
+### Tests
+- Added unit coverage for `ResultExt::ctx`, ensuring happy-path results pass
+  through and error branches preserve metadata and sources.
+
 ## [0.12.0] - 2025-10-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "actix-web",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.12.0"
+version = "0.12.1"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ guides, comparisons with `thiserror`/`anyhow`, and troubleshooting recipes.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.12.0", default-features = false }
+masterror = { version = "0.12.1", default-features = false }
 # or with features:
-# masterror = { version = "0.12.0", features = [
+# masterror = { version = "0.12.1", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -75,10 +75,10 @@ masterror = { version = "0.12.0", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.12.0", default-features = false }
+masterror = { version = "0.12.1", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.12.0", features = [
+# masterror = { version = "0.12.1", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
@@ -637,13 +637,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.12.0", default-features = false }
+masterror = { version = "0.12.1", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.12.0", features = [
+masterror = { version = "0.12.1", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -652,7 +652,7 @@ masterror = { version = "0.12.0", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.12.0", features = [
+masterror = { version = "0.12.1", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/README.ru.md
+++ b/README.ru.md
@@ -38,9 +38,9 @@
 ~~~toml
 [dependencies]
 # минимальное ядро
-masterror = { version = "0.12.0", default-features = false }
+masterror = { version = "0.12.1", default-features = false }
 # или с нужными интеграциями
-# masterror = { version = "0.12.0", features = [
+# masterror = { version = "0.12.1", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",

--- a/src/app_error.rs
+++ b/src/app_error.rs
@@ -60,11 +60,13 @@
 //! transport boundary (e.g. in `IntoResponse`) to avoid duplicate logs.
 
 mod constructors;
+mod context;
 mod core;
 mod metadata;
 
 pub use core::{AppError, AppResult, Error, MessageEditPolicy};
 
+pub use context::Context;
 pub use metadata::{Field, FieldValue, Metadata, field};
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,7 @@ mod kind;
 #[doc(hidden)]
 pub mod provide;
 mod response;
+mod result_ext;
 
 #[cfg(feature = "frontend")]
 #[cfg_attr(docsrs, doc(cfg(feature = "frontend")))]
@@ -246,7 +247,7 @@ pub mod turnkey;
 pub mod prelude;
 
 pub use app_error::{
-    AppError, AppResult, Error, Field, FieldValue, MessageEditPolicy, Metadata, field
+    AppError, AppResult, Context, Error, Field, FieldValue, MessageEditPolicy, Metadata, field
 };
 pub use code::AppCode;
 pub use kind::AppErrorKind;
@@ -278,3 +279,4 @@ pub use kind::AppErrorKind;
 /// ```
 pub use masterror_derive::*;
 pub use response::{ErrorResponse, RetryAdvice};
+pub use result_ext::ResultExt;

--- a/src/result_ext.rs
+++ b/src/result_ext.rs
@@ -1,0 +1,152 @@
+use std::error::Error as StdError;
+
+use crate::app_error::{Context, Error};
+
+/// Extension trait for enriching `Result` errors with [`Context`].
+///
+/// The [`ctx`](ResultExt::ctx) method converts the error side of a `Result`
+/// into [`Error`] while attaching metadata, category and edit policy captured
+/// by [`Context`].
+///
+/// # Examples
+///
+/// ```rust
+/// use std::io::{Error as IoError, ErrorKind};
+///
+/// use masterror::{AppErrorKind, Context, ResultExt, field};
+///
+/// fn validate() -> Result<(), IoError> {
+///     Err(IoError::from(ErrorKind::Other))
+/// }
+///
+/// let err = validate()
+///     .ctx(|| Context::new(AppErrorKind::Validation).with(field::str("phase", "validate")))
+///     .unwrap_err();
+///
+/// assert_eq!(err.kind, AppErrorKind::Validation);
+/// assert!(err.metadata().get("phase").is_some());
+/// ```
+pub trait ResultExt<T, E> {
+    /// Convert an error into [`Error`] using [`Context`] supplied by `build`.
+    #[allow(clippy::result_large_err)]
+    fn ctx(self, build: impl FnOnce() -> Context) -> Result<T, Error>
+    where
+        E: StdError + Send + Sync + 'static;
+}
+
+impl<T, E> ResultExt<T, E> for Result<T, E> {
+    fn ctx(self, build: impl FnOnce() -> Context) -> Result<T, Error>
+    where
+        E: StdError + Send + Sync + 'static
+    {
+        self.map_err(|err| build().into_error(err))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        borrow::Cow,
+        error::Error as StdError,
+        fmt::{Display, Formatter, Result as FmtResult},
+        sync::Arc
+    };
+
+    use super::ResultExt;
+    use crate::{
+        AppCode, AppErrorKind,
+        app_error::{Context, FieldValue, MessageEditPolicy},
+        field
+    };
+
+    #[derive(Debug)]
+    struct DummyError;
+
+    impl Display for DummyError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+            f.write_str("dummy")
+        }
+    }
+
+    impl StdError for DummyError {}
+
+    #[test]
+    fn ctx_preserves_ok() {
+        let res: Result<u8, DummyError> = Ok(5);
+        let value = res
+            .ctx(|| Context::new(AppErrorKind::Internal))
+            .expect("ok");
+        assert_eq!(value, 5);
+    }
+
+    #[test]
+    fn ctx_wraps_err_with_context() {
+        let result: Result<(), DummyError> = Err(DummyError);
+        let err = result
+            .ctx(|| {
+                Context::new(AppErrorKind::Service)
+                    .with(field::str("operation", "sync"))
+                    .redact(true)
+                    .track_caller()
+            })
+            .expect_err("err");
+
+        assert_eq!(err.kind, AppErrorKind::Service);
+        assert_eq!(err.code, AppCode::Service);
+        assert!(matches!(err.edit_policy, MessageEditPolicy::Redact));
+
+        let metadata = err.metadata();
+        assert_eq!(
+            metadata.get("operation"),
+            Some(&FieldValue::Str(Cow::Borrowed("sync")))
+        );
+        let caller_file = metadata.get("caller.file").expect("caller file field");
+        assert_eq!(caller_file, &FieldValue::Str(Cow::Borrowed(file!())));
+        assert!(metadata.get("caller.line").is_some());
+        assert!(metadata.get("caller.column").is_some());
+    }
+
+    #[derive(Debug, Clone)]
+    struct SharedError(Arc<InnerError>);
+
+    #[derive(Debug)]
+    struct InnerError;
+
+    impl Display for InnerError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+            f.write_str("inner")
+        }
+    }
+
+    impl StdError for InnerError {}
+
+    impl Display for SharedError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+            Display::fmt(&*self.0, f)
+        }
+    }
+
+    impl StdError for SharedError {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            Some(&*self.0)
+        }
+    }
+
+    #[test]
+    fn ctx_preserves_source_without_extra_arc_clone() {
+        let inner = Arc::new(InnerError);
+        let shared = SharedError(inner.clone());
+        let err = Result::<(), SharedError>::Err(shared.clone())
+            .ctx(|| Context::new(AppErrorKind::Internal))
+            .expect_err("err");
+
+        drop(shared);
+        assert_eq!(Arc::strong_count(&inner), 2);
+
+        let stored = err
+            .source_ref()
+            .and_then(|src| src.downcast_ref::<SharedError>())
+            .expect("shared source");
+        assert!(Arc::ptr_eq(&stored.0, &inner));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce the `app_error::Context` builder for configuring codes, metadata, caller tracking, and redaction flags when promoting errors
- add the `ResultExt::ctx` helper with tests to wrap `Result` errors into `masterror::Error`, and re-export the new API surface
- bump the crate to 0.12.1, updating changelog and README versions alongside new rustdoc examples

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68d1f743d8a8832b99ec94c65b03a12d