### PR TITLE
Add telemetry hook and optional error metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.0] - 2025-09-24
+
+### Added
+- Introduced optional `tracing`, `metrics` and `backtrace` features. When
+  enabled they emit structured `tracing` events, increment the
+  `error_total{code,category}` counter and capture lazy [`Backtrace`] snapshots
+  from a new `AppError::emit_telemetry` hook.
+
+### Changed
+- Reworked the `AppError` core to emit telemetry exactly once, track dirty
+  mutations and expose a crate-private `new_raw` constructor for contexts that
+  enrich errors before flushing instrumentation.
+- Updated Axum and Actix integrations to rely on the telemetry hook instead of
+  manually logging errors while preserving backward-compatible APIs.
+
+### Tests
+- Added tracing dispatcher coverage to assert a single telemetry event with MDC
+  propagated `trace_id` values.
+- Installed a deterministic metrics recorder in unit tests to confirm
+  `error_total` increments once per error.
+
 ## [0.13.1] - 2025-09-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,15 +1624,18 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "actix-web",
  "axum",
  "config",
  "http 1.3.1",
  "js-sys",
+ "log",
+ "log-mdc",
  "masterror-derive",
  "masterror-template",
+ "metrics",
  "redis",
  "reqwest",
  "serde",
@@ -1628,6 +1649,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-subscriber",
  "trybuild",
  "utoipa",
  "uuid",
@@ -1670,6 +1692,16 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "metrics"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
 
 [[package]]
 name = "mime"
@@ -1723,6 +1755,15 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1971,6 +2012,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
@@ -2675,6 +2722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,6 +3182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3358,6 +3423,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3531,6 +3622,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.13.1"
+version = "0.14.0"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -50,6 +50,9 @@ readme = "README.md"
 
 [features]
 default = []
+tracing = ["dep:tracing", "dep:log", "dep:log-mdc"]
+metrics = ["dep:metrics"]
+backtrace = []
 axum = ["dep:axum", "dep:serde_json"]
 actix = ["dep:actix-web", "dep:serde_json"]
 
@@ -77,7 +80,10 @@ masterror-template = { version = "0.3.6" }
 [dependencies]
 masterror-derive = { version = "0.7" }
 masterror-template = { workspace = true }
-tracing = "0.1"
+tracing = { version = "0.1", optional = true }
+log = { version = "0.4", optional = true }
+log-mdc = { version = "0.1", optional = true }
+metrics = { version = "0.24", optional = true }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
@@ -125,6 +131,7 @@ tokio = { version = "1", features = [
 trybuild = "1"
 toml = "0.9"
 tempfile = "3"
+tracing-subscriber = { version = "0.3", features = ["registry"] }
 
 [build-dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -136,6 +143,9 @@ feature_order = [
   "actix",
   "openapi",
   "serde_json",
+  "tracing",
+  "metrics",
+  "backtrace",
   "sqlx",
   "sqlx-migrate",
   "reqwest",
@@ -175,6 +185,15 @@ description = "Generate utoipa OpenAPI schema for ErrorResponse"
 
 [package.metadata.masterror.readme.features.serde_json]
 description = "Attach structured JSON details to AppError"
+
+[package.metadata.masterror.readme.features.tracing]
+description = "Emit structured tracing events when errors are constructed"
+
+[package.metadata.masterror.readme.features.metrics]
+description = "Increment `error_total{code,category}` counter for each AppError"
+
+[package.metadata.masterror.readme.features.backtrace]
+description = "Capture lazy `Backtrace` snapshots when telemetry is flushed"
 
 [package.metadata.masterror.readme.features.sqlx]
 description = "Classify sqlx_core::Error variants into AppError kinds"

--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ guides, comparisons with `thiserror`/`anyhow`, and troubleshooting recipes.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.13.1", default-features = false }
+masterror = { version = "0.14.0", default-features = false }
 # or with features:
-# masterror = { version = "0.13.1", features = [
+# masterror = { version = "0.14.0", features = [
 #   "axum", "actix", "openapi", "serde_json",
-#   "sqlx", "sqlx-migrate", "reqwest", "redis",
-#   "validator", "config", "tokio", "multipart",
-#   "teloxide", "telegram-webapp-sdk", "frontend", "turnkey"
+#   "tracing", "metrics", "backtrace", "sqlx",
+#   "sqlx-migrate", "reqwest", "redis", "validator",
+#   "config", "tokio", "multipart", "teloxide",
+#   "telegram-webapp-sdk", "frontend", "turnkey"
 # ] }
 ~~~
 
@@ -76,14 +77,15 @@ masterror = { version = "0.13.1", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.13.1", default-features = false }
+masterror = { version = "0.14.0", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.13.1", features = [
+# masterror = { version = "0.14.0", features = [
 #   "axum", "actix", "openapi", "serde_json",
-#   "sqlx", "sqlx-migrate", "reqwest", "redis",
-#   "validator", "config", "tokio", "multipart",
-#   "teloxide", "telegram-webapp-sdk", "frontend", "turnkey"
+#   "tracing", "metrics", "backtrace", "sqlx",
+#   "sqlx-migrate", "reqwest", "redis", "validator",
+#   "config", "tokio", "multipart", "teloxide",
+#   "telegram-webapp-sdk", "frontend", "turnkey"
 # ] }
 ~~~
 
@@ -671,6 +673,9 @@ assert_eq!(resp.status, 401);
 - `actix` — Actix Web ResponseError and Responder implementations
 - `openapi` — Generate utoipa OpenAPI schema for ErrorResponse
 - `serde_json` — Attach structured JSON details to AppError
+- `tracing` — Emit structured tracing events when errors are constructed
+- `metrics` — Increment `error_total{code,category}` counter for each AppError
+- `backtrace` — Capture lazy `Backtrace` snapshots when telemetry is flushed
 - `sqlx` — Classify sqlx_core::Error variants into AppError kinds
 - `sqlx-migrate` — Map sqlx::migrate::MigrateError into AppError (Database)
 - `reqwest` — Classify reqwest::Error as timeout/network/external API
@@ -709,13 +714,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.13.1", default-features = false }
+masterror = { version = "0.14.0", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.13.1", features = [
+masterror = { version = "0.14.0", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -724,7 +729,7 @@ masterror = { version = "0.13.1", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.13.1", features = [
+masterror = { version = "0.14.0", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/src/app_error.rs
+++ b/src/app_error.rs
@@ -53,11 +53,14 @@
 //! }
 //! ```
 //!
-//! ## Logging
+//! ## Telemetry
 //!
-//! [`AppError::log`] emits a single structured `tracing::error!` event with
-//! `kind`, `code` and optional `message` fields. Prefer calling it at the
-//! transport boundary (e.g. in `IntoResponse`) to avoid duplicate logs.
+//! [`AppError::log`] flushes telemetry once: it emits a structured `tracing`
+//! event (when the `tracing` feature is enabled), increments the
+//! `error_total{code,category}` counter (with the `metrics` feature) and
+//! captures a lazy [`Backtrace`] snapshot (with the `backtrace` feature).
+//! Constructors and framework integrations call it automatically, so manual
+//! usage is rarely required.
 
 mod constructors;
 mod context;

--- a/src/app_error/constructors.rs
+++ b/src/app_error/constructors.rs
@@ -62,8 +62,8 @@ impl AppError {
     /// assert!(err.message.is_none());
     /// ```
     pub fn database(msg: Option<Cow<'static, str>>) -> Self {
-        let mut err = Self::bare(AppErrorKind::Database);
-        err.message = msg;
+        let err = Self::new_raw(AppErrorKind::Database, msg);
+        err.emit_telemetry();
         err
     }
 

--- a/src/app_error/context.rs
+++ b/src/app_error/context.rs
@@ -129,13 +129,16 @@ impl Context {
             ));
         }
 
-        let mut error = AppError::bare(self.category).with_code(self.code);
+        let mut error = AppError::new_raw(self.category, None);
+        error.code = self.code;
         if !self.fields.is_empty() {
-            error = error.with_fields(self.fields);
+            error.metadata.extend(self.fields);
         }
         if matches!(self.edit_policy, MessageEditPolicy::Redact) {
-            error = error.redactable();
+            error.edit_policy = MessageEditPolicy::Redact;
         }
-        error.with_source(source)
+        let error = error.with_source(source);
+        error.emit_telemetry();
+        error
     }
 }

--- a/src/convert/actix.rs
+++ b/src/convert/actix.rs
@@ -85,6 +85,7 @@ impl ResponseError for AppError {
 
     /// Produce JSON body with `ErrorResponse`. Does not leak sources.
     fn error_response(&self) -> HttpResponse {
+        self.emit_telemetry();
         let body = ErrorResponse::from(self);
         let mut builder = HttpResponse::build(self.status_code());
         if let Some(retry) = body.retry {

--- a/src/response/axum_impl.rs
+++ b/src/response/axum_impl.rs
@@ -42,8 +42,9 @@ impl IntoResponse for ErrorResponse {
 /// Convert `AppError` into the stable wire model and reuse its `IntoResponse`.
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        // Use the canonical mapping defined in `From<&AppError> for ErrorResponse`
-        let wire: ErrorResponse = (&self).into();
+        let err = self;
+        err.emit_telemetry();
+        let wire: ErrorResponse = err.into();
         wire.into_response()
     }
 }


### PR DESCRIPTION
## Summary
- add an `AppError::emit_telemetry` hook that captures backtraces lazily, records metrics and emits tracing events exactly once per error
- wire constructors, context conversions and framework integrations through the telemetry hook so HTTP responses flush instrumentation automatically
- add optional `metrics`/`log-mdc` dependencies, bump the crate to 0.14.0, refresh docs and expand tests to cover tracing MDC propagation and counter increments

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68d210622424832bbbf643d917c07023