### PR TITLE
Fix clippy regressions and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.1] - 2025-09-24
+
+### Fixed
+- Removed the unused `BacktraceSlot::get` helper to restore builds with `-D warnings`.
+- Simplified the metrics recorder test harness with dedicated types to satisfy
+  `clippy::type_complexity` without sacrificing coverage.
+
 ## [0.14.0] - 2025-09-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "actix-web",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.14.0"
+version = "0.14.1"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ guides, comparisons with `thiserror`/`anyhow`, and troubleshooting recipes.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.14.0", default-features = false }
+masterror = { version = "0.14.1", default-features = false }
 # or with features:
-# masterror = { version = "0.14.0", features = [
+# masterror = { version = "0.14.1", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "tracing", "metrics", "backtrace", "sqlx",
 #   "sqlx-migrate", "reqwest", "redis", "validator",
@@ -77,10 +77,10 @@ masterror = { version = "0.14.0", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.14.0", default-features = false }
+masterror = { version = "0.14.1", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.14.0", features = [
+# masterror = { version = "0.14.1", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "tracing", "metrics", "backtrace", "sqlx",
 #   "sqlx-migrate", "reqwest", "redis", "validator",
@@ -714,13 +714,13 @@ assert_eq!(resp.status, 401);
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.14.0", default-features = false }
+masterror = { version = "0.14.1", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.14.0", features = [
+masterror = { version = "0.14.1", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -729,7 +729,7 @@ masterror = { version = "0.14.0", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.14.0", features = [
+masterror = { version = "0.14.1", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/src/app_error/core.rs
+++ b/src/app_error/core.rs
@@ -48,10 +48,6 @@ impl BacktraceSlot {
         *self = Self::with(backtrace);
     }
 
-    fn get(&self) -> Option<&Backtrace> {
-        self.cell.get().and_then(|value| value.as_ref())
-    }
-
     fn capture_if_absent(&self) -> Option<&Backtrace> {
         self.cell
             .get_or_init(|| Some(Backtrace::capture()))

--- a/src/app_error/tests.rs
+++ b/src/app_error/tests.rs
@@ -313,28 +313,44 @@ fn metrics_counter_is_incremented_once() {
         Counter, CounterFn, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit
     };
 
+    #[derive(Clone, Debug, Eq, PartialEq, Hash)]
+    struct CounterKey {
+        name:   String,
+        labels: Vec<(String, String)>
+    }
+
+    impl CounterKey {
+        fn new(name: String, labels: Vec<(String, String)>) -> Self {
+            Self {
+                name,
+                labels
+            }
+        }
+    }
+
+    type CounterMap = HashMap<CounterKey, u64>;
+    type SharedCounterMap = Arc<Mutex<CounterMap>>;
+
     #[derive(Clone)]
     struct MetricsCounterHandle {
-        name:   String,
-        labels: Vec<(String, String)>,
-        counts: Arc<Mutex<HashMap<(String, Vec<(String, String)>), u64>>>
+        key:    CounterKey,
+        counts: SharedCounterMap
     }
 
     impl CounterFn for MetricsCounterHandle {
         fn increment(&self, value: u64) {
             let mut map = self.counts.lock().expect("counter map");
-            *map.entry((self.name.clone(), self.labels.clone()))
-                .or_default() += value;
+            *map.entry(self.key.clone()).or_default() += value;
         }
 
         fn absolute(&self, value: u64) {
             let mut map = self.counts.lock().expect("counter map");
-            map.insert((self.name.clone(), self.labels.clone()), value);
+            map.insert(self.key.clone(), value);
         }
     }
 
     struct CountingRecorder {
-        counts: Arc<Mutex<HashMap<(String, Vec<(String, String)>), u64>>>
+        counts: SharedCounterMap
     }
 
     impl Recorder for CountingRecorder {
@@ -361,9 +377,9 @@ fn metrics_counter_is_incremented_once() {
                 .labels()
                 .map(|label| (label.key().to_owned(), label.value().to_owned()))
                 .collect::<Vec<_>>();
+            let counter_key = CounterKey::new(key.name().to_owned(), labels);
             Counter::from_arc(Arc::new(MetricsCounterHandle {
-                name: key.name().to_owned(),
-                labels,
+                key:    counter_key,
                 counts: self.counts.clone()
             }))
         }
@@ -379,8 +395,7 @@ fn metrics_counter_is_incremented_once() {
 
     use std::sync::OnceLock;
 
-    static RECORDER_COUNTS: OnceLock<Arc<Mutex<HashMap<(String, Vec<(String, String)>), u64>>>> =
-        OnceLock::new();
+    static RECORDER_COUNTS: OnceLock<SharedCounterMap> = OnceLock::new();
 
     let counts = RECORDER_COUNTS
         .get_or_init(|| {
@@ -398,7 +413,7 @@ fn metrics_counter_is_incremented_once() {
     let err = AppError::forbidden("denied");
     err.log();
 
-    let key = (
+    let key = CounterKey::new(
         "error_total".to_owned(),
         vec![
             ("code".to_owned(), AppCode::Forbidden.as_str().to_owned()),


### PR DESCRIPTION
## Summary
- remove the unused `BacktraceSlot::get` helper that triggered `-D warnings`
- refactor the metrics recorder tests to reuse a typed counter key and silence the type complexity lint
- bump the crate to version 0.14.1 and refresh documentation/changelog entries

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check


------
https://chatgpt.com/codex/tasks/task_e_68d22f2d0464832b82e99ed6aca8e7cb