### PR TITLE
feat: store shared sources and lazy backtraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.19.0] - 2025-09-29
+
+### Changed
+- Reworked `AppError` storage to keep sources behind shared `Arc` handles and
+  lazily capture optional `Backtrace` snapshots without allocating when
+  `RUST_BACKTRACE` disables them.
+- Updated the `masterror::Error` derive and `ResultExt` conversions to forward
+  sources/backtraces automatically under the new storage layout.
+
+### Tests
+- Added regression coverage for chained error sources and conditional
+  backtrace capture driven by the `RUST_BACKTRACE` environment variable.
+
 ## [0.18.0] - 2025-09-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "actix-web",
  "axum 0.8.4",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.18.0"
+version = "0.19.0"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -75,11 +75,11 @@ tonic = ["dep:tonic"]
 openapi = ["dep:utoipa"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.8.0" }
+masterror-derive = { version = "0.9.0" }
 masterror-template = { version = "0.3.6" }
 
 [dependencies]
-masterror-derive = { version = "0.8" }
+masterror-derive = { version = "0.9" }
 masterror-template = { workspace = true }
 tracing = { version = "0.1", optional = true }
 log = { version = "0.4", optional = true }

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ guides, comparisons with `thiserror`/`anyhow`, and troubleshooting recipes.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.18.0", default-features = false }
+masterror = { version = "0.19.0", default-features = false }
 # or with features:
-# masterror = { version = "0.18.0", features = [
+# masterror = { version = "0.19.0", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "tracing", "metrics", "backtrace", "sqlx",
 #   "sqlx-migrate", "reqwest", "redis", "validator",
@@ -78,10 +78,10 @@ masterror = { version = "0.18.0", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.18.0", default-features = false }
+masterror = { version = "0.19.0", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.18.0", features = [
+# masterror = { version = "0.19.0", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "tracing", "metrics", "backtrace", "sqlx",
 #   "sqlx-migrate", "reqwest", "redis", "validator",
@@ -720,13 +720,13 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.18.0", default-features = false }
+masterror = { version = "0.19.0", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.18.0", features = [
+masterror = { version = "0.19.0", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -735,7 +735,7 @@ masterror = { version = "0.18.0", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.18.0", features = [
+masterror = { version = "0.19.0", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.90"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/src/app_error.rs
+++ b/src/app_error.rs
@@ -67,6 +67,8 @@ mod context;
 mod core;
 mod metadata;
 
+#[cfg(all(test, feature = "backtrace"))]
+pub(crate) use core::reset_backtrace_preference;
 pub use core::{AppError, AppResult, Error, MessageEditPolicy};
 
 pub use context::Context;

--- a/tests/masterror_macro.rs
+++ b/tests/masterror_macro.rs
@@ -1,6 +1,6 @@
 #![allow(non_shorthand_field_patterns)]
 
-use std::sync::Arc;
+use std::{error::Error as StdError, sync::Arc};
 
 use masterror::{
     AppCode, AppErrorKind, Error as MasterrorError, FieldRedaction, Masterror, MessageEditPolicy,
@@ -96,6 +96,8 @@ fn struct_masterror_conversion_populates_metadata_and_source() {
     assert_eq!(attempt, Some(3));
 
     assert!(converted.source_ref().is_some());
+    let converted_source = StdError::source(&converted).expect("masterror source");
+    assert!(converted_source.is::<std::io::Error>());
 
     assert_eq!(
         MissingFlag::HTTP_MAPPING,


### PR DESCRIPTION
## Summary
- store `AppError` sources behind shared `Arc` handles and capture optional backtraces lazily under the `backtrace` feature with `RUST_BACKTRACE`
- wire the derive and `ResultExt` conversions through the new storage so source chains and backtrace snapshots are preserved automatically
- bump the workspace crates to 0.19.0/0.9.0 and document the behaviour in the changelog and README

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68d337593bf8832b8a92921925dc7d73