### PR TITLE
Restore integrations and prepare 0.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.20.3] - 2025-10-03
+
+### Fixed
+- Restored the Axum transport adapter in builds by wiring the `convert::axum`
+  module into the crate graph and relaxing the tests to validate responses via
+  `serde_json::Value` instead of requiring `ProblemJson` deserialization.
+- Hardened converter telemetry for Redis, Reqwest, SQLx, Tonic and multipart
+  integrations by owning metadata strings where necessary and covering
+  non-exhaustive enums so the crate compiles cleanly on Rust 1.90.
+- Reworked `ProblemJson` metadata internals to use `Cow<'static, str>` keys and
+  values, preserving zero-copy behaviour for borrowed data while allowing owned
+  fallbacks required by the updated converters.
+
 ## [0.20.2] - 2025-10-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "actix-web",
  "axum 0.8.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.20.2"
+version = "0.20.3"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ guides, comparisons with `thiserror`/`anyhow`, and troubleshooting recipes.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.20.2", default-features = false }
+masterror = { version = "0.20.3", default-features = false }
 # or with features:
-# masterror = { version = "0.20.2", features = [
+# masterror = { version = "0.20.3", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "tracing", "metrics", "backtrace", "sqlx",
 #   "sqlx-migrate", "reqwest", "redis", "validator",
@@ -78,10 +78,10 @@ masterror = { version = "0.20.2", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.20.2", default-features = false }
+masterror = { version = "0.20.3", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.20.2", features = [
+# masterror = { version = "0.20.3", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "tracing", "metrics", "backtrace", "sqlx",
 #   "sqlx-migrate", "reqwest", "redis", "validator",
@@ -720,13 +720,13 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.20.2", default-features = false }
+masterror = { version = "0.20.3", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.20.2", features = [
+masterror = { version = "0.20.3", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -735,7 +735,7 @@ masterror = { version = "0.20.2", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.20.2", features = [
+masterror = { version = "0.20.3", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -78,6 +78,10 @@ use std::io::Error as IoError;
 
 use crate::AppError;
 
+#[cfg(feature = "axum")]
+#[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
+mod axum;
+
 #[cfg(all(feature = "axum", feature = "multipart"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "axum", feature = "multipart"))))]
 mod multipart;

--- a/src/convert/multipart.rs
+++ b/src/convert/multipart.rs
@@ -38,7 +38,7 @@ mod tests {
         http::Request
     };
 
-    use crate::{AppErrorKind, FieldValue};
+    use crate::{AppErrorKind, Error, FieldValue};
 
     #[tokio::test]
     async fn multipart_error_maps_to_bad_request() {

--- a/src/convert/redis.rs
+++ b/src/convert/redis.rs
@@ -59,7 +59,7 @@ impl From<RedisError> for Error {
 fn build_context(err: &RedisError) -> (Context, Option<u64>) {
     let mut context = Context::new(AppErrorKind::Cache)
         .with(field::str("redis.kind", format!("{:?}", err.kind())))
-        .with(field::str("redis.category", err.category()))
+        .with(field::str("redis.category", err.category().to_owned()))
         .with(field::bool("redis.is_timeout", err.is_timeout()))
         .with(field::bool(
             "redis.is_cluster_error",
@@ -115,7 +115,8 @@ const fn retry_method_details(method: RetryMethod) -> (&'static str, Option<u64>
         RetryMethod::ReconnectFromInitialConnections => {
             ("ReconnectFromInitialConnections", Some(1))
         }
-        RetryMethod::WaitAndRetry => ("WaitAndRetry", Some(2))
+        RetryMethod::WaitAndRetry => ("WaitAndRetry", Some(2)),
+        _ => ("Other", None)
     }
 }
 

--- a/src/convert/reqwest.rs
+++ b/src/convert/reqwest.rs
@@ -107,7 +107,7 @@ fn classify_reqwest_error(err: &ReqwestError) -> (Context, Option<u64>) {
 
     if let Some(url) = err.url() {
         context = context
-            .with(field::str("http.url", url.as_str()))
+            .with(field::str("http.url", url.to_string()))
             .redact_field("http.url", FieldRedaction::Hash);
 
         if let Some(host) = url.host_str() {

--- a/src/convert/sqlx.rs
+++ b/src/convert/sqlx.rs
@@ -242,7 +242,7 @@ fn classify_database_error(error: &(dyn DatabaseError + 'static)) -> (Context, O
         SqlxErrorKind::NotNullViolation | SqlxErrorKind::CheckViolation => {
             AppErrorKind::Validation
         }
-        SqlxErrorKind::Other => AppErrorKind::Database
+        _ => AppErrorKind::Database
     };
 
     context = context.category(category);
@@ -420,7 +420,8 @@ mod tests_sqlx {
                 SqlxErrorKind::ForeignKeyViolation => SqlxErrorKind::ForeignKeyViolation,
                 SqlxErrorKind::NotNullViolation => SqlxErrorKind::NotNullViolation,
                 SqlxErrorKind::CheckViolation => SqlxErrorKind::CheckViolation,
-                SqlxErrorKind::Other => SqlxErrorKind::Other
+                SqlxErrorKind::Other => SqlxErrorKind::Other,
+                _ => SqlxErrorKind::Other
             }
         }
     }

--- a/src/convert/tonic.rs
+++ b/src/convert/tonic.rs
@@ -110,7 +110,7 @@ fn insert_ascii(meta: &mut MetadataMap, key: &'static str, value: impl AsRef<str
     if !is_ascii_metadata_value(value) {
         return;
     }
-    if let Ok(metadata_value) = MetadataValue::try_from(value.as_ref()) {
+    if let Ok(metadata_value) = MetadataValue::try_from(value) {
         let _ = meta.insert(key, metadata_value);
     }
 }

--- a/src/response/problem_json.rs
+++ b/src/response/problem_json.rs
@@ -100,7 +100,7 @@ pub struct GrpcCode {
 pub struct ProblemJson {
     /// Canonical type URI describing the problem class.
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub type_uri:         Option<&'static str>,
+    pub type_uri:         Option<Cow<'static, str>>,
     /// Short, human-friendly title describing the error category.
     pub title:            Cow<'static, str>,
     /// HTTP status code returned to the client.
@@ -159,7 +159,7 @@ impl ProblemJson {
         let metadata = sanitize_metadata_owned(metadata, edit_policy);
 
         Self {
-            type_uri: Some(mapping.problem_type()),
+            type_uri: Some(Cow::Borrowed(mapping.problem_type())),
             title,
             status,
             detail,
@@ -195,7 +195,7 @@ impl ProblemJson {
         let metadata = sanitize_metadata_ref(error.metadata(), error.edit_policy);
 
         Self {
-            type_uri: Some(mapping.problem_type()),
+            type_uri: Some(Cow::Borrowed(mapping.problem_type())),
             title,
             status,
             detail,
@@ -231,7 +231,7 @@ impl ProblemJson {
         };
 
         Self {
-            type_uri: Some(mapping.problem_type()),
+            type_uri: Some(Cow::Borrowed(mapping.problem_type())),
             title: Cow::Owned(mapping.kind().to_string()),
             status: response.status,
             detail,
@@ -284,7 +284,7 @@ impl ProblemJson {
 /// ```
 #[derive(Clone, Debug, Serialize)]
 #[serde(transparent)]
-pub struct ProblemMetadata(BTreeMap<&'static str, ProblemMetadataValue>);
+pub struct ProblemMetadata(BTreeMap<Cow<'static, str>, ProblemMetadataValue>);
 
 impl ProblemMetadata {
     #[cfg(test)]
@@ -373,7 +373,7 @@ fn sanitize_metadata_owned(
     for field in metadata {
         let (name, value, redaction) = field.into_parts();
         if let Some(sanitized) = sanitize_problem_metadata_value_owned(value, redaction) {
-            public.insert(name, sanitized);
+            public.insert(Cow::Borrowed(name), sanitized);
         }
     }
 
@@ -395,7 +395,7 @@ fn sanitize_metadata_ref(
     let mut public = BTreeMap::new();
     for (name, value, redaction) in metadata.iter_with_redaction() {
         if let Some(sanitized) = sanitize_problem_metadata_value_ref(value, redaction) {
-            public.insert(name, sanitized);
+            public.insert(Cow::Borrowed(name), sanitized);
         }
     }
 


### PR DESCRIPTION
## Summary
- restore the axum integration module and update response tests to assert over `serde_json::Value`
- harden converter metadata for redis/reqwest/sqlx/tonic and switch `ProblemJson` metadata storage to `Cow`
- bump the crate to version 0.20.3 with changelog and README updates

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit --color never
- cargo deny check


------
https://chatgpt.com/codex/tasks/task_e_68d3722b95b0832b826449da70bc7cb1