### PR TITLE
Fix tonic conversion clippy warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.20.5] - 2025-10-05
+
+### Fixed
+- Promoted the gRPC converter to an infallible `From<Error>` implementation
+  while retaining the `TryFrom` API via the new documented
+  `StatusConversionError`, satisfying Clippy's infallible conversion lint.
+- Collapsed nested metadata guards in the Tonic adapter and reused borrowed
+  booleans to silence Clippy without regressing runtime behaviour.
+- Simplified the `AppResult` alias test to avoid large `Err` variant warnings
+  from Clippy's `result_large_err` lint.
+
 ## [0.20.4] - 2025-10-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "actix-web",
  "axum 0.8.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.20.4"
+version = "0.20.5"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ guides, comparisons with `thiserror`/`anyhow`, and troubleshooting recipes.
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.20.4", default-features = false }
+masterror = { version = "0.20.5", default-features = false }
 # or with features:
-# masterror = { version = "0.20.4", features = [
+# masterror = { version = "0.20.5", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "tracing", "metrics", "backtrace", "sqlx",
 #   "sqlx-migrate", "reqwest", "redis", "validator",
@@ -78,10 +78,10 @@ masterror = { version = "0.20.4", default-features = false }
 ~~~toml
 [dependencies]
 # lean core
-masterror = { version = "0.20.4", default-features = false }
+masterror = { version = "0.20.5", default-features = false }
 
 # with Axum/Actix + JSON + integrations
-# masterror = { version = "0.20.4", features = [
+# masterror = { version = "0.20.5", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "tracing", "metrics", "backtrace", "sqlx",
 #   "sqlx-migrate", "reqwest", "redis", "validator",
@@ -720,13 +720,13 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 Minimal core:
 
 ~~~toml
-masterror = { version = "0.20.4", default-features = false }
+masterror = { version = "0.20.5", default-features = false }
 ~~~
 
 API (Axum + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.20.4", features = [
+masterror = { version = "0.20.5", features = [
   "axum", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }
@@ -735,7 +735,7 @@ masterror = { version = "0.20.4", features = [
 API (Actix + JSON + deps):
 
 ~~~toml
-masterror = { version = "0.20.4", features = [
+masterror = { version = "0.20.5", features = [
   "actix", "serde_json", "openapi",
   "sqlx", "reqwest", "redis", "validator", "config", "tokio"
 ] }

--- a/src/app_error/tests.rs
+++ b/src/app_error/tests.rs
@@ -537,14 +537,9 @@ fn metrics_counter_is_incremented_once() {
 
 #[test]
 fn result_alias_is_generic() {
-    fn app() -> super::AppResult<u8> {
-        Ok(1)
-    }
+    let default_result: super::AppResult<u8> = Ok(1);
+    let custom_result: super::AppResult<u8, &'static str> = Ok(2);
 
-    fn other() -> super::AppResult<u8, &'static str> {
-        Ok(2)
-    }
-
-    assert_eq!(app().unwrap(), 1);
-    assert_eq!(other().unwrap(), 2);
+    assert_eq!(default_result.unwrap(), 1);
+    assert_eq!(custom_result.unwrap(), 2);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,3 +363,7 @@ pub use response::{
     }
 };
 pub use result_ext::ResultExt;
+
+#[cfg(feature = "tonic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tonic")))]
+pub use crate::convert::tonic::StatusConversionError;


### PR DESCRIPTION
## Summary
- switch the tonic adapter to an infallible `From<Error>` conversion while keeping `TryFrom` available via a documented `StatusConversionError`
- tighten metadata handling and bool serialization in the tonic converter and simplify the `AppResult` alias test to satisfy clippy
- bump the crate to v0.20.5 and document the release details in the changelog and README

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68d37fa0a7f4832b83abf875fd599810