### PR TITLE
Fix Tonic conversion tests and release 0.20.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.20.7] - 2025-10-07
+
+### Fixed
+- Replaced the remaining fallible `Status::try_from` conversions in the Tonic
+  adapter tests with the infallible `Status::from` API so Clippy's
+  `unnecessary_fallible_conversions` lint passes under `-D warnings`.
+
 ## [0.20.6] - 2025-10-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.20.6"
+version = "0.20.7"
 dependencies = [
  "actix-web",
  "axum 0.8.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.20.6"
+version = "0.20.7"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.20.6", default-features = false }
+masterror = { version = "0.20.7", default-features = false }
 # or with features:
-# masterror = { version = "0.20.6", features = [
+# masterror = { version = "0.20.7", features = [
 #   "axum", "actix", "openapi", "serde_json",
 #   "tracing", "metrics", "backtrace", "sqlx",
 #   "sqlx-migrate", "reqwest", "redis", "validator",

--- a/src/app_error/tests.rs
+++ b/src/app_error/tests.rs
@@ -540,6 +540,6 @@ fn result_alias_is_generic() {
     let default_result: super::AppResult<u8> = Ok(1);
     let custom_result: super::AppResult<u8, &'static str> = Ok(2);
 
-    assert_eq!(default_result.unwrap(), 1);
-    assert_eq!(custom_result.unwrap(), 2);
+    assert!(matches!(default_result, Ok(value) if value == 1));
+    assert!(matches!(custom_result, Ok(value) if value == 2));
 }

--- a/src/convert/tonic.rs
+++ b/src/convert/tonic.rs
@@ -167,7 +167,7 @@ mod tests {
     fn status_maps_codes_correctly() {
         for (code, mapping) in CODE_MAPPINGS.iter() {
             let err = AppError::with(mapping.kind(), format!("{:?}", code));
-            let status = Status::try_from(err).expect("status");
+            let status = Status::from(err);
             assert_eq!(status.code(), Code::from_i32(mapping.grpc().value));
             let expected_detail = format!("{:?}", code);
             assert_eq!(
@@ -184,7 +184,7 @@ mod tests {
         let err = AppError::internal("secret")
             .redactable()
             .with_field(field::str("request_id", "abc"));
-        let status = Status::try_from(err).expect("status");
+        let status = Status::from(err);
         assert_eq!(status.message(), AppErrorKind::Internal.to_string());
         assert!(status.metadata().get("request_id").is_none());
     }
@@ -194,7 +194,7 @@ mod tests {
         let err = AppError::service("downstream")
             .with_field(field::str("request_id", "abc"))
             .with_field(field::u64("attempt", 2));
-        let status = Status::try_from(err).expect("status");
+        let status = Status::from(err);
         assert_eq!(
             status
                 .metadata()


### PR DESCRIPTION
## Summary
- switch the tonic conversion tests to the infallible `Status::from` API so clippy stops flagging unnecessary fallible conversions
- rewrite the `AppResult` alias regression test to assert through pattern matching instead of literal `unwrap`
- bump the crate metadata to 0.20.7 and update the changelog/README accordingly

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy --all-features --all-targets -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68d39d164ba8832ba3ec5ec711cad59e