### PR TITLE
Fix unused import warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.23.2] - 2025-10-14
+
+### Fixed
+- Removed an unused `String` import from the response details module to keep
+  builds warning-free under `-D warnings`.
+
 ## [0.23.1] - 2025-10-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.23.1"
+version = "0.23.2"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/src/response/details.rs
+++ b/src/response/details.rs
@@ -63,6 +63,5 @@ impl ErrorResponse {
         Ok(self.with_details_json(details))
     }
 }
-use alloc::string::String;
 #[cfg(feature = "serde_json")]
 use alloc::string::ToString;


### PR DESCRIPTION
## Summary
- remove the unused `String` import in the response details module to satisfy `-D warnings`
- bump the crate version to 0.23.2 and record the change in the changelog

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo +1.90.0 audit
- cargo +1.90.0 deny check

------
https://chatgpt.com/codex/tasks/task_e_68d6534965a8832b81250b9b3b903b82