### PR TITLE
Use stack buffers for metadata redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.23.3] - 2025-10-15
+
+### Changed
+- Replaced temporary `String` allocations in RFC7807 metadata hashing and masking
+  with stack buffers to keep the textual representations and digests stable
+  while avoiding heap usage.
+
+### Added
+- Regression tests covering hashed and last-four redaction paths for numeric,
+  UUID, and IP metadata to guarantee the legacy formatting remains unchanged.
+
 ## [0.23.2] - 2025-10-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,13 +1665,14 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "actix-web",
  "anyhow",
  "axum",
  "config",
  "http 1.3.1",
+ "itoa",
  "js-sys",
  "log",
  "log-mdc",
@@ -1680,6 +1681,7 @@ dependencies = [
  "metrics",
  "redis",
  "reqwest",
+ "ryu",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.23.2"
+version = "0.23.3"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -99,6 +99,8 @@ serde_json = { version = "1", optional = true, default-features = false, feature
 ] }
 http = "1"
 sha2 = "0.10"
+itoa = "1"
+ryu = "1"
 
 # optional integrations
 axum = { version = "0.8", optional = true, default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.23.1", default-features = false }
+masterror = { version = "0.23.3", default-features = false }
 # or with features:
-# masterror = { version = "0.23.1", features = [
+# masterror = { version = "0.23.3", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",


### PR DESCRIPTION
## Summary
- replace temporary `String` allocations in problem metadata hashing/masking with stack-backed buffers while keeping the emitted text and digests unchanged
- extend the problem-json tests to cover hash/last4 redaction of numeric, UUID, and IP metadata
- bump the crate version to 0.23.3 and document the change in the changelog/README snippet

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68d667f787e8832bb8227d73911f7aeb