### PR TITLE
Move AppCode out of context when promoting errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.1] - 2025-10-17
+
+### Fixed
+- Updated `Context::into_error` to move dynamic `AppCode` values into the
+  resulting `AppError`, reworking field redaction plumbing to avoid clones and
+  preserve custom code ownership. Added a regression test covering pointer
+  identity for context-promoted errors.
+
 ## [0.24.0] - 2025-10-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.24.0"
+version = "0.24.1"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.24.0", default-features = false }
+masterror = { version = "0.24.1", default-features = false }
 # or with features:
-# masterror = { version = "0.24.0", features = [
+# masterror = { version = "0.24.1", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",

--- a/tests/ui/app_error/fail/enum_missing_variant.stderr
+++ b/tests/ui/app_error/fail/enum_missing_variant.stderr
@@ -1,9 +1,8 @@
 error: all variants must use #[app_error(...)] to derive AppError conversion
  --> tests/ui/app_error/fail/enum_missing_variant.rs:8:5
   |
-8 | /     #[error("without")]
-9 | |     Without,
-  | |___________^
+8 |     #[error("without")]
+  |     ^
 
 warning: unused import: `AppErrorKind`
  --> tests/ui/app_error/fail/enum_missing_variant.rs:1:17
@@ -11,4 +10,4 @@ warning: unused import: `AppErrorKind`
 1 | use masterror::{AppErrorKind, Error};
   |                 ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/ui/app_error/fail/missing_code.stderr
+++ b/tests/ui/app_error/fail/missing_code.stderr
@@ -2,7 +2,7 @@ error: AppCode conversion requires `code = ...` in #[app_error(...)]
  --> tests/ui/app_error/fail/missing_code.rs:9:5
   |
 9 |     #[app_error(kind = AppErrorKind::Service)]
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |     ^
 
 warning: unused imports: `AppCode` and `AppErrorKind`
  --> tests/ui/app_error/fail/missing_code.rs:1:17
@@ -10,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Error};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/ui/app_error/fail/missing_kind.stderr
+++ b/tests/ui/app_error/fail/missing_kind.stderr
@@ -2,4 +2,4 @@ error: missing `kind = ...` in #[app_error(...)]
  --> tests/ui/app_error/fail/missing_kind.rs:5:1
   |
 5 | #[app_error(message)]
-  | ^^^^^^^^^^^^^^^^^^^^^
+  | ^

--- a/tests/ui/formatter/fail/duplicate_fmt.stderr
+++ b/tests/ui/formatter/fail/duplicate_fmt.stderr
@@ -2,4 +2,4 @@ error: duplicate `fmt` handler specified
  --> tests/ui/formatter/fail/duplicate_fmt.rs:4:36
   |
 4 | #[error(fmt = crate::format_error, fmt = crate::format_error)]
-  |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                                    ^^^

--- a/tests/ui/formatter/fail/implicit_after_named.stderr
+++ b/tests/ui/formatter/fail/implicit_after_named.stderr
@@ -8,5 +8,4 @@ error: multiple unused formatting arguments
   |                 argument never used
   |                 argument never used
   |
-  = note: consider adding 2 format specifiers
   = note: this error originates in the derive macro `Error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/formatter/fail/unsupported_flag.stderr
+++ b/tests/ui/formatter/fail/unsupported_flag.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..11 uses an unsupported formatter
- --> tests/ui/formatter/fail/unsupported_flag.rs:4:10
+ --> tests/ui/formatter/fail/unsupported_flag.rs:4:9
   |
 4 | #[error("{value:##x}")]
-  |          ^^^^^^^^^^^
+  |         ^^^^^^^^^^^^^

--- a/tests/ui/formatter/fail/unsupported_formatter.stderr
+++ b/tests/ui/formatter/fail/unsupported_formatter.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..9 uses an unsupported formatter
- --> tests/ui/formatter/fail/unsupported_formatter.rs:4:10
+ --> tests/ui/formatter/fail/unsupported_formatter.rs:4:9
   |
 4 | #[error("{value:y}")]
-  |          ^^^^^^^^^
+  |         ^^^^^^^^^^^

--- a/tests/ui/formatter/fail/uppercase_binary.stderr
+++ b/tests/ui/formatter/fail/uppercase_binary.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..9 uses an unsupported formatter
- --> tests/ui/formatter/fail/uppercase_binary.rs:4:10
+ --> tests/ui/formatter/fail/uppercase_binary.rs:4:9
   |
 4 | #[error("{value:B}")]
-  |          ^^^^^^^^^
+  |         ^^^^^^^^^^^

--- a/tests/ui/formatter/fail/uppercase_pointer.stderr
+++ b/tests/ui/formatter/fail/uppercase_pointer.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..9 uses an unsupported formatter
- --> tests/ui/formatter/fail/uppercase_pointer.rs:4:10
+ --> tests/ui/formatter/fail/uppercase_pointer.rs:4:9
   |
 4 | #[error("{value:P}")]
-  |          ^^^^^^^^^
+  |         ^^^^^^^^^^^

--- a/tests/ui/masterror/fail/duplicate_attr.stderr
+++ b/tests/ui/masterror/fail/duplicate_attr.stderr
@@ -10,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Masterror};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/ui/masterror/fail/duplicate_telemetry.stderr
+++ b/tests/ui/masterror/fail/duplicate_telemetry.stderr
@@ -10,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Masterror};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/ui/masterror/fail/empty_redact.stderr
+++ b/tests/ui/masterror/fail/empty_redact.stderr
@@ -10,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Masterror};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/ui/masterror/fail/enum_missing_variant.stderr
+++ b/tests/ui/masterror/fail/enum_missing_variant.stderr
@@ -1,9 +1,8 @@
 error: all variants must use #[masterror(...)] to derive masterror::Error conversion
  --> tests/ui/masterror/fail/enum_missing_variant.rs:8:5
   |
-8 | /     #[error("missing")]
-9 | |     Missing
-  | |___________^
+8 |     #[error("missing")]
+  |     ^
 
 warning: unused imports: `AppCode` and `AppErrorKind`
  --> tests/ui/masterror/fail/enum_missing_variant.rs:1:17
@@ -11,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Masterror};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/ui/masterror/fail/missing_category.stderr
+++ b/tests/ui/masterror/fail/missing_category.stderr
@@ -2,7 +2,7 @@ error: missing `category = ...` in #[masterror(...)]
  --> tests/ui/masterror/fail/missing_category.rs:5:1
   |
 5 | #[masterror(code = AppCode::Internal)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^
 
 warning: unused import: `AppCode`
  --> tests/ui/masterror/fail/missing_category.rs:1:17
@@ -10,4 +10,4 @@ warning: unused import: `AppCode`
 1 | use masterror::{AppCode, Masterror};
   |                 ^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/ui/masterror/fail/missing_code.stderr
+++ b/tests/ui/masterror/fail/missing_code.stderr
@@ -2,7 +2,7 @@ error: missing `code = ...` in #[masterror(...)]
  --> tests/ui/masterror/fail/missing_code.rs:5:1
   |
 5 | #[masterror(category = AppErrorKind::Internal)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^
 
 warning: unused import: `AppErrorKind`
  --> tests/ui/masterror/fail/missing_code.rs:1:17
@@ -10,4 +10,4 @@ warning: unused import: `AppErrorKind`
 1 | use masterror::{AppErrorKind, Masterror};
   |                 ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default

--- a/tests/ui/masterror/fail/unknown_option.stderr
+++ b/tests/ui/masterror/fail/unknown_option.stderr
@@ -10,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Masterror};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default


### PR DESCRIPTION
## Summary
- move `Context::into_error` to transfer its `AppCode` into the constructed `AppError` while keeping field redaction helpers working with moved metadata
- add a regression test that proves dynamically created codes are moved (pointer identity) and refresh trybuild snapshots for the current compiler diagnostics
- bump the crate to 0.24.1 with changelog and README updates reflecting the fix

## Testing
- cargo +nightly fmt --
- cargo build --all-targets
- cargo test --all
- cargo clippy -- -D warnings
- cargo doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68d7196177a0832b8863c84291a3c91d