### PR TITLE
Optimize context field redaction application

### DIFF
--- a/src/app_error/context.rs
+++ b/src/app_error/context.rs
@@ -89,9 +89,16 @@ impl Context {
 
     /// Attach a metadata [`Field`].
     #[must_use]
-    pub fn with(mut self, field: Field) -> Self {
+    pub fn with(mut self, mut field: Field) -> Self {
+        if let Some((_, policy)) = self
+            .field_policies
+            .iter()
+            .rev()
+            .find(|(name, _)| *name == field.name())
+        {
+            field.set_redaction(*policy);
+        }
         self.fields.push(field);
-        Self::apply_field_redactions(&mut self.fields, &self.field_policies);
         self
     }
 


### PR DESCRIPTION
## Summary
- apply the most recent redaction policy directly when adding fields via `Context::with`
- extend context builder tests to cover default and overridden field redaction behaviour

## Testing
- cargo +nightly fmt --
- cargo build --all-targets
- cargo clippy -- -D warnings
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68d71f910094832b922307178939736c