### PR TITLE
Optimize tonic metadata serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.3] - 2025-10-19
+
+### Fixed
+- Reused stack-allocated format buffers when emitting gRPC metadata for HTTP
+  status codes and retry hints, and added regression coverage to ensure metadata
+  strings remain ASCII encoded.
+
 ## [0.24.2] - 2025-10-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.24.2"
+version = "0.24.3"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.24.2", default-features = false }
+masterror = { version = "0.24.3", default-features = false }
 # or with features:
-# masterror = { version = "0.24.2", features = [
+# masterror = { version = "0.24.3", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",


### PR DESCRIPTION
## Summary
- reuse stack-based formatting for gRPC HTTP status and retry metadata in the tonic converter
- add a regression test around `Status::from(AppError::timeout(..))` to lock down metadata strings
- bump the crate to 0.24.3 and refresh the changelog and README snippet

## Testing
- cargo +nightly fmt --
- cargo +nightly clippy -- -D warnings
- cargo +nightly build --all-targets
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68d746bf4f08832bbcf33fd9d76d2443