### PR TITLE
Use stack buffers for Retry-After headers

### DIFF
--- a/src/response/actix_impl.rs
+++ b/src/response/actix_impl.rs
@@ -12,6 +12,7 @@ use actix_web::{
     body::BoxBody,
     http::header::{CONTENT_TYPE, RETRY_AFTER, WWW_AUTHENTICATE}
 };
+use itoa::Buffer as IntegerBuffer;
 
 use super::{ErrorResponse, ProblemJson};
 
@@ -26,7 +27,9 @@ pub(crate) fn respond_with_problem_json(mut problem: ProblemJson) -> HttpRespons
     builder.insert_header((CONTENT_TYPE, "application/problem+json"));
 
     if let Some(retry) = retry_after {
-        builder.insert_header((RETRY_AFTER, retry.to_string()));
+        let mut buffer = IntegerBuffer::new();
+        let retry_str = buffer.format(retry);
+        builder.insert_header((RETRY_AFTER, retry_str));
     }
     if let Some(challenge) = www_authenticate {
         builder.insert_header((WWW_AUTHENTICATE, challenge));

--- a/src/response/axum_impl.rs
+++ b/src/response/axum_impl.rs
@@ -16,6 +16,7 @@ use axum::{
     },
     response::{IntoResponse, Response}
 };
+use itoa::Buffer as IntegerBuffer;
 
 use super::{ErrorResponse, ProblemJson};
 
@@ -32,10 +33,12 @@ impl IntoResponse for ProblemJson {
             HeaderValue::from_static("application/problem+json")
         );
 
-        if let Some(retry) = retry_after
-            && let Ok(hv) = HeaderValue::from_str(&retry.to_string())
-        {
-            response.headers_mut().insert(RETRY_AFTER, hv);
+        if let Some(retry) = retry_after {
+            let mut buffer = IntegerBuffer::new();
+            let retry_str = buffer.format(retry);
+            if let Ok(hv) = HeaderValue::from_str(retry_str) {
+                response.headers_mut().insert(RETRY_AFTER, hv);
+            }
         }
         if let Some(challenge) = www_authenticate
             && let Ok(hv) = HeaderValue::from_str(&challenge)

--- a/src/response/tests.rs
+++ b/src/response/tests.rs
@@ -389,9 +389,13 @@ fn axum_into_response_sets_headers_and_status() {
 
     assert_eq!(resp.status(), 401);
     let headers = resp.headers();
-    assert_eq!(headers.get(RETRY_AFTER).unwrap(), "7");
+    let retry_after = headers.get(RETRY_AFTER).expect("Retry-After");
+    assert_eq!(retry_after.to_str().expect("ASCII value"), "7");
+    let www_authenticate = headers
+        .get(WWW_AUTHENTICATE)
+        .expect("WWW-Authenticate header");
     assert_eq!(
-        headers.get(WWW_AUTHENTICATE).unwrap(),
+        www_authenticate.to_str().expect("ASCII challenge"),
         r#"Bearer realm="api", error="invalid_token""#
     );
 }
@@ -424,8 +428,15 @@ fn actix_responder_sets_headers_and_status() {
     assert_eq!(http.status(), StatusCode::TOO_MANY_REQUESTS);
 
     let headers = http.headers();
-    assert_eq!(headers.get(RETRY_AFTER).unwrap(), "42");
-    assert_eq!(headers.get(WWW_AUTHENTICATE).unwrap(), "Bearer");
+    let retry_after = headers.get(RETRY_AFTER).expect("Retry-After");
+    assert_eq!(retry_after.to_str().expect("ASCII value"), "42");
+    let www_authenticate = headers
+        .get(WWW_AUTHENTICATE)
+        .expect("WWW-Authenticate header");
+    assert_eq!(
+        www_authenticate.to_str().expect("ASCII challenge"),
+        "Bearer"
+    );
 }
 
 #[cfg(feature = "actix")]


### PR DESCRIPTION
## Summary
- avoid allocating when emitting `Retry-After` in the axum and actix integrations by formatting into stack buffers
- extend the feature-gated adapter tests to assert the ASCII header values remain intact

## Testing
- cargo build --all-targets
- cargo clippy -- -D warnings
- cargo test --all
- cargo test --all --features "axum actix"
- cargo doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68d778d705f0832bb9ed7df8df45feb4