### PR TITLE
Validate legacy error response statuses

### DIFF
--- a/src/response/legacy.rs
+++ b/src/response/legacy.rs
@@ -1,3 +1,5 @@
+use http::StatusCode;
+
 use super::core::ErrorResponse;
 use crate::AppCode;
 
@@ -12,15 +14,29 @@ impl ErrorResponse {
     /// ease migration from versions prior to 0.3.0.
     #[must_use]
     pub fn new_legacy(status: u16, message: impl Into<String>) -> Self {
-        let msg = message.into();
-        Self::new(status, AppCode::Internal, msg.clone()).unwrap_or(Self {
-            status:           500,
-            code:             AppCode::Internal,
-            message:          msg,
-            details:          None,
-            retry:            None,
-            www_authenticate: None
-        })
+        match StatusCode::from_u16(status) {
+            Ok(_) => {
+                let message = message.into();
+                Self {
+                    status,
+                    code: AppCode::Internal,
+                    message,
+                    details: None,
+                    retry: None,
+                    www_authenticate: None
+                }
+            }
+            Err(_) => {
+                let message = message.into();
+                Self {
+                    status: 500,
+                    code: AppCode::Internal,
+                    message,
+                    details: None,
+                    retry: None,
+                    www_authenticate: None
+                }
+            }
+        }
     }
 }
-use alloc::string::String;

--- a/src/response/tests.rs
+++ b/src/response/tests.rs
@@ -365,7 +365,16 @@ fn display_is_concise_and_does_not_leak_details() {
 #[allow(deprecated)]
 #[test]
 fn new_legacy_defaults_to_internal_code() {
-    let e = ErrorResponse::new_legacy(500, "boom");
+    let e = ErrorResponse::new_legacy(404, "boom");
+    assert_eq!(e.status, 404);
+    assert!(matches!(e.code, AppCode::Internal));
+    assert_eq!(e.message, "boom");
+}
+
+#[allow(deprecated)]
+#[test]
+fn new_legacy_invalid_status_falls_back_to_internal_error() {
+    let e = ErrorResponse::new_legacy(0, "boom");
     assert_eq!(e.status, 500);
     assert!(matches!(e.code, AppCode::Internal));
     assert_eq!(e.message, "boom");


### PR DESCRIPTION
## Summary
- validate `ErrorResponse::new_legacy` status codes before constructing responses
- reuse the provided message without cloning when the status is valid or invalid
- add regression coverage for both valid and fallback code paths of the legacy constructor

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68d77de97238832ba4497b48b5fc64bb