### PR TITLE
Optimize context metadata redaction handling

### DIFF
--- a/src/app_error/context.rs
+++ b/src/app_error/context.rs
@@ -173,9 +173,10 @@ impl Context {
         if !fields.is_empty() {
             Self::apply_field_redactions(&mut fields, &field_policies);
             error.metadata.extend(fields);
-        }
-        for &(name, redaction) in &field_policies {
-            error = error.redact_field(name, redaction);
+        } else if !field_policies.is_empty() {
+            for &(name, redaction) in &field_policies {
+                error = error.redact_field(name, redaction);
+            }
         }
         if matches!(edit_policy, MessageEditPolicy::Redact) {
             error.edit_policy = MessageEditPolicy::Redact;

--- a/src/app_error/tests.rs
+++ b/src/app_error/tests.rs
@@ -336,6 +336,21 @@ fn context_redact_field_overrides_policy() {
 }
 
 #[test]
+fn context_redact_field_before_insertion_applies_policy() {
+    let err = super::Context::new(AppErrorKind::Service)
+        .redact_field("token", FieldRedaction::Hash)
+        .with(field::str("token", "super-secret"))
+        .into_error(DummyError);
+
+    let metadata = err.metadata();
+    assert_eq!(
+        metadata.get("token"),
+        Some(&FieldValue::Str(Cow::Borrowed("super-secret")))
+    );
+    assert_eq!(metadata.redaction("token"), Some(FieldRedaction::Hash));
+}
+
+#[test]
 fn context_redact_field_mut_applies_policies() {
     let mut context = super::Context::new(AppErrorKind::Service);
     let _ = context.redact_field_mut("token", FieldRedaction::Hash);


### PR DESCRIPTION
## Summary
- avoid reapplying field redaction policies when context metadata already reflects them while preserving the fallback for contexts without fields
- add a unit test to cover policies applied before metadata insertion

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68d781a1f09c832b81a49c6fa8991158