### PR TITLE
Fix benchmark black_box usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.5] - 2025-10-21
+
+### Fixed
+- Replaced deprecated `criterion::black_box` usage in the error path benchmarks
+  with `std::hint::black_box` so benches compile cleanly under `-D warnings`.
+
 ## [0.24.4] - 2025-10-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.24.4"
+version = "0.24.5"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.24.4", default-features = false }
+masterror = { version = "0.24.5", default-features = false }
 # or with features:
-# masterror = { version = "0.24.4", features = [
+# masterror = { version = "0.24.5", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",

--- a/benches/error_paths.rs
+++ b/benches/error_paths.rs
@@ -2,9 +2,12 @@ use core::{
     net::{IpAddr, Ipv4Addr},
     time::Duration
 };
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::{
+    fmt::{Display, Formatter, Result as FmtResult},
+    hint::black_box
+};
 
-use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use masterror::{AppError, AppErrorKind, Context, FieldRedaction, ProblemJson, ResultExt, field};
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- switch the error path benchmarks to `std::hint::black_box` to silence the Criterion deprecation warning
- bump the crate version to 0.24.5, document the change in the changelog, and refresh the README dependency snippet

## Testing
- `cargo +nightly fmt --`
- `cargo +1.90.0 clippy -- -D warnings`
- `cargo +1.90.0 build --all-targets`
- `cargo +1.90.0 test --all`
- `cargo +1.90.0 doc --no-deps`
- `cargo audit`
- `cargo deny check`


------
https://chatgpt.com/codex/tasks/task_e_68d7c5a98c18832bb2643129e65e1ae5