### PR TITLE
Fix no_std doc build regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.6] - 2025-10-22
+
+### Fixed
+- Restored `no_std` builds by importing `alloc::String` for response helpers and
+  the legacy constructor, keeping textual detail setters available without the
+  `std` feature.
+- Ensured `AppCode::from_str` remains available in `no_std` mode by explicitly
+  bringing `ToOwned` into scope and gated the `std::io::Error` conversion example
+  so doctests compile without the standard library.
+
 ## [0.24.5] - 2025-10-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.24.5"
+version = "0.24.6"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.24.5"
+version = "0.24.6"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.24.5", default-features = false }
+masterror = { version = "0.24.6", default-features = false }
 # or with features:
-# masterror = { version = "0.24.5", features = [
+# masterror = { version = "0.24.6", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",

--- a/src/code/app_code.rs
+++ b/src/code/app_code.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, string::String};
+use alloc::{borrow::ToOwned, boxed::Box, string::String};
 use core::{
     error::Error as CoreError,
     fmt::{self, Display},

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -44,6 +44,8 @@
 //! `std::io::Error` mapping:
 //!
 //! ```rust
+//! # #[cfg(feature = "std")]
+//! # {
 //! use std::io::{self, ErrorKind};
 //!
 //! use masterror::{AppError, AppErrorKind, AppResult};
@@ -55,6 +57,7 @@
 //!
 //! let err = open().unwrap_err();
 //! assert!(matches!(err.kind, AppErrorKind::Internal));
+//! # }
 //! ```
 //!
 //! `String` mapping (useful for ad-hoc validation without the `validator`

--- a/src/response/details.rs
+++ b/src/response/details.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "serde_json"))]
+use alloc::string::String;
+
 #[cfg(feature = "serde_json")]
 use serde::Serialize;
 #[cfg(feature = "serde_json")]

--- a/src/response/legacy.rs
+++ b/src/response/legacy.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 use http::StatusCode;
 
 use super::core::ErrorResponse;


### PR DESCRIPTION
## Summary
- import `alloc::String` for response helpers so `no_std` builds compile again
- gate the `std::io::Error` conversion example and pull in `ToOwned` for `AppCode::from_str`
- bump `masterror` to 0.24.6 with changelog and README updates

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo test --doc -p masterror --no-default-features`
- `cargo doc --no-deps`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68d7d2baaaa0832ba85a27f9b43a8154