### PR TITLE
Raise MSRV to Rust 1.90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.8] - 2025-10-24
+
+### Changed
+- Raised the documented and enforced MSRV to Rust 1.90 across the workspace to
+  satisfy dependencies that no longer compile on Rust 1.89.
+
 ## [0.24.7] - 2025-10-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1818,7 +1818,7 @@ dependencies = [
  "js-sys",
  "log",
  "log-mdc",
- "masterror-derive 0.9.1",
+ "masterror-derive 0.9.2",
  "masterror-template",
  "metrics",
  "redis",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "masterror-template",
  "proc-macro2",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-template"
-version = "0.3.7"
+version = "0.3.8"
 
 [[package]]
 name = "matchit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror"
-version = "0.24.7"
-rust-version = "1.89"
+version = "0.24.8"
+rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"
@@ -42,7 +42,7 @@ resolver = "3"
 # Defaults for members (root объявлен строками выше, потому что build.rs парсит его как строки)
 [workspace.package]
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.90"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"
 readme = "README.md"
@@ -76,8 +76,8 @@ tonic = ["dep:tonic", "std"]
 openapi = ["dep:utoipa", "std"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.9.1" }
-masterror-template = { version = "0.3.7" }
+masterror-derive = { version = "0.9.2" }
+masterror-template = { version = "0.3.8" }
 
 [dependencies]
 masterror-derive = { version = "0.9" }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Crates.io](https://img.shields.io/crates/v/masterror)](https://crates.io/crates/masterror)
 [![docs.rs](https://img.shields.io/docsrs/masterror)](https://docs.rs/masterror)
 [![Downloads](https://img.shields.io/crates/d/masterror)](https://crates.io/crates/masterror)
-![MSRV](https://img.shields.io/badge/MSRV-1.89-blue)
+![MSRV](https://img.shields.io/badge/MSRV-1.90-blue)
 ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
 [![CI](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 [![Security audit](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main&label=Security%20audit)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
@@ -74,9 +74,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.24.7", default-features = false }
+masterror = { version = "0.24.8", default-features = false }
 # or with features:
-# masterror = { version = "0.24.7", features = [
+# masterror = { version = "0.24.8", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
@@ -445,4 +445,4 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 
 ---
 
-MSRV: **1.89** · License: **MIT OR Apache-2.0** · No `unsafe`
+MSRV: **1.90** · License: **MIT OR Apache-2.0** · No `unsafe`

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/masterror)](https://crates.io/crates/masterror)
 [![docs.rs](https://img.shields.io/docsrs/masterror)](https://docs.rs/masterror)
 [![Downloads](https://img.shields.io/crates/d/masterror)](https://crates.io/crates/masterror)
-![MSRV](https://img.shields.io/badge/MSRV-1.89-blue)
+![MSRV](https://img.shields.io/badge/MSRV-1.90-blue)
 ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
 [![CI](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 [![Security audit](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main&label=Security%20audit)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
@@ -364,4 +364,4 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 
 ---
 
-MSRV: **1.89** · Лицензия: **MIT OR Apache-2.0** · Без `unsafe`
+MSRV: **1.90** · Лицензия: **MIT OR Apache-2.0** · Без `unsafe`

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-derive"
-rust-version = "1.89"
-version = "0.9.1"
+rust-version = "1.90"
+version = "0.9.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RAprogramm/masterror"

--- a/masterror-template/Cargo.toml
+++ b/masterror-template/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masterror-template"
-version = "0.3.7"
-rust-version = "1.89"
+version = "0.3.8"
+rust-version = "1.90"
 edition = "2024"
 repository = "https://github.com/RAprogramm/masterror"
 readme = "README.md"

--- a/masterror-template/README.md
+++ b/masterror-template/README.md
@@ -10,10 +10,10 @@ Add the crate alongside `masterror` if you need direct access to the parser:
 
 ```toml
 [dependencies]
-masterror-template = { version = "0.3.7" }
+masterror-template = { version = "0.3.8" }
 ```
 
-`masterror-template` targets Rust 1.89 and builds on stable and nightly toolchains alike.
+`masterror-template` targets Rust 1.90 and builds on stable and nightly toolchains alike.
 
 ## Parsing templates
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! MSRV is **1.89**. New minor releases may increase MSRV with a changelog
+//! MSRV is **1.90**. New minor releases may increase MSRV with a changelog
 //! note, but never in a patch release.
 //!
 //! # Feature flags

--- a/src/turnkey/classifier.rs
+++ b/src/turnkey/classifier.rs
@@ -193,7 +193,7 @@ const fn is_ascii_alphanumeric(byte: u8) -> bool {
 /// Converts ASCII letters to lowercase and leaves other bytes unchanged.
 #[inline]
 const fn ascii_lower(b: u8) -> u8 {
-    // ASCII-only fold without RangeInclusive to keep const-friendly on MSRV 1.89
+    // ASCII-only fold without RangeInclusive to keep const-friendly on MSRV 1.90
     if b >= b'A' && b <= b'Z' { b + 32 } else { b }
 }
 

--- a/tests/readme_sync.rs
+++ b/tests/readme_sync.rs
@@ -8,7 +8,7 @@ use tempfile::tempdir;
 const MINIMAL_MANIFEST: &str = r#"[package]
 name = "demo"
 version = "1.2.3"
-rust-version = "1.89"
+rust-version = "1.90"
 edition = "2024"
 
 [features]


### PR DESCRIPTION
## Summary
- bump the workspace MSRV to Rust 1.90 and update crate versions accordingly
- refresh README content, tests, and changelog entries to document the new requirement

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo +1.90.0 audit
- cargo +1.90.0 deny check

------
https://chatgpt.com/codex/tasks/task_e_68d7e4e81aa0832ba636d067ceaa1397