### PR TITLE
Fix docs build on docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.10] - 2025-10-26
+
+### Fixed
+- Removed the deprecated `doc_auto_cfg` rustdoc feature gate so documentation
+  builds succeed on the docs.rs nightly toolchain again.
+
 ## [0.24.9] - 2025-10-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.24.9"
+version = "0.24.10"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.24.9"
+version = "0.24.10"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.24.9", default-features = false }
+masterror = { version = "0.24.10", default-features = false }
 # or with features:
-# masterror = { version = "0.24.9", features = [
+# masterror = { version = "0.24.10", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
@@ -446,4 +446,3 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 ---
 
 MSRV: **1.90** · License: **MIT OR Apache-2.0** · No `unsafe`
-

--- a/src/convert/axum.rs
+++ b/src/convert/axum.rs
@@ -47,7 +47,8 @@ use axum::{
 use crate::{AppError, response::ProblemJson};
 
 impl AppError {
-    /// Map this error to an HTTP status derived from its [`AppErrorKind`].
+    /// Map this error to an HTTP status derived from its
+    /// [`crate::AppErrorKind`].
     ///
     /// This is the transport-specific view over the framework-agnostic
     /// `AppErrorKind::http_status()` mapping.

--- a/src/convert/redis.rs
+++ b/src/convert/redis.rs
@@ -38,7 +38,7 @@ use redis::{ErrorKind, RedisError, RetryMethod};
 #[cfg(feature = "redis")]
 use crate::{AppErrorKind, Context, Error, field};
 
-/// Map any [`redis::RedisError`] into an [`AppError`] with kind `Cache`.
+/// Map any [`redis::RedisError`] into an [`crate::AppError`] with kind `Cache`.
 ///
 /// Rationale: Redis is treated as a backend cache dependency.
 /// Detailed driver errors are kept in the message for diagnostics.

--- a/src/convert/reqwest.rs
+++ b/src/convert/reqwest.rs
@@ -49,7 +49,8 @@ use reqwest::{Error as ReqwestError, StatusCode};
 
 use crate::{AppErrorKind, Context, Error, FieldRedaction, field};
 
-/// Map a [`reqwest::Error`] into an [`Error`] according to its category.
+/// Map a [`reqwest::Error`] into an [`struct@crate::Error`] according to its
+/// category.
 ///
 /// - Timeout → `Timeout`
 /// - Connect or request build error → `Network`

--- a/src/convert/serde_json.rs
+++ b/src/convert/serde_json.rs
@@ -39,7 +39,7 @@ use serde_json::{Error as SjError, error::Category};
 #[cfg(feature = "serde_json")]
 use crate::{AppErrorKind, Context, Error, field};
 
-/// Map a [`serde_json::Error`] into an [`AppError`].
+/// Map a [`serde_json::Error`] into an [`crate::AppError`].
 ///
 /// Errors are classified to `Serialization` or `Deserialization` using
 /// [`serde_json::Error::classify`]. The original error string is preserved for

--- a/src/convert/sqlx.rs
+++ b/src/convert/sqlx.rs
@@ -53,7 +53,7 @@ const SQLSTATE_CODE_OVERRIDES: &[(&str, AppCode)] = &[
 #[cfg(feature = "sqlx")]
 const SQLSTATE_RETRY_HINTS: &[(&str, u64)] = &[("40001", 1), ("55P03", 1)];
 
-/// Map a `sqlx_core::error::Error` into [`Error`].
+/// Map a `sqlx_core::error::Error` into [`struct@crate::Error`].
 ///
 /// - `RowNotFound` → `AppErrorKind::NotFound`
 /// - database constraint errors attach SQLSTATE and constraint metadata
@@ -71,7 +71,7 @@ impl From<SqlxError> for Error {
     }
 }
 
-/// Map a `sqlx::migrate::MigrateError` into [`Error`].
+/// Map a `sqlx::migrate::MigrateError` into [`struct@crate::Error`].
 ///
 /// Errors are categorised as `Database` with metadata describing the failing
 /// migration phase.

--- a/src/convert/telegram_webapp_sdk.rs
+++ b/src/convert/telegram_webapp_sdk.rs
@@ -41,7 +41,8 @@ use telegram_webapp_sdk::utils::validate_init_data::ValidationError;
 #[cfg(feature = "telegram-webapp-sdk")]
 use crate::{AppErrorKind, Context, Error, field};
 
-/// Map [`ValidationError`] into an [`AppError`] with kind `TelegramAuth`.
+/// Map [`ValidationError`] into an [`crate::AppError`] with kind
+/// `TelegramAuth`.
 #[cfg(feature = "telegram-webapp-sdk")]
 #[cfg_attr(docsrs, doc(cfg(feature = "telegram-webapp-sdk")))]
 impl From<ValidationError> for Error {

--- a/src/convert/tokio.rs
+++ b/src/convert/tokio.rs
@@ -38,7 +38,7 @@ use tokio::time::error::Elapsed;
 #[cfg(feature = "tokio")]
 use crate::{AppErrorKind, Context, Error, field};
 
-/// Map a [`tokio::time::error::Elapsed`] into an [`AppError`] with kind
+/// Map a [`tokio::time::error::Elapsed`] into an [`crate::AppError`] with kind
 /// `Timeout`.
 ///
 /// Message is fixed to avoid leaking timing specifics to the client.

--- a/src/convert/validator.rs
+++ b/src/convert/validator.rs
@@ -44,7 +44,7 @@ use validator::{ValidationErrors, ValidationErrorsKind};
 #[cfg(feature = "validator")]
 use crate::{AppErrorKind, Context, Error, field};
 
-/// Map [`validator::ValidationErrors`] into an [`AppError`] with kind
+/// Map [`validator::ValidationErrors`] into an [`crate::AppError`] with kind
 /// `Validation`.
 ///
 /// By default, the error is converted to a string for human-readable logs.

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -2,7 +2,7 @@
 //! values.
 //!
 //! This module is available when the `frontend` feature is enabled. It provides
-//! helpers to serialize [`AppError`] and [`ErrorResponse`] into
+//! helpers to serialize [`crate::AppError`] and [`crate::ErrorResponse`] into
 //! [`wasm_bindgen::JsValue`] and optionally emit structured logs via
 //! `console.error` when running inside a browser.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
     rust_2018_idioms,
     clippy::all
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Framework-agnostic application error types for backend services.
 //!

--- a/src/turnkey.rs
+++ b/src/turnkey.rs
@@ -1,11 +1,11 @@
 //! Turnkey integration: error kinds, classification, and conversions.
 //!
 //! This module centralizes Turnkey-specific error taxonomy and mapping into
-//! framework-agnostic [`AppError`] and [`AppErrorKind`].
+//! framework-agnostic [`crate::AppError`] and [`crate::AppErrorKind`].
 //!
 //! # Goals
 //! - Stable domain kinds (`TurnkeyErrorKind`) decoupled from SDK texts.
-//! - Conservative mapping to the canonical [`AppErrorKind`].
+//! - Conservative mapping to the canonical [`crate::AppErrorKind`].
 //! - Heuristic classifier for stringly-typed upstream errors.
 //!
 //! # Examples

--- a/tests/ui/app_error/fail/enum_missing_variant.stderr
+++ b/tests/ui/app_error/fail/enum_missing_variant.stderr
@@ -1,8 +1,9 @@
 error: all variants must use #[app_error(...)] to derive AppError conversion
  --> tests/ui/app_error/fail/enum_missing_variant.rs:8:5
   |
-8 |     #[error("without")]
-  |     ^
+8 | /     #[error("without")]
+9 | |     Without,
+  | |___________^
 
 warning: unused import: `AppErrorKind`
  --> tests/ui/app_error/fail/enum_missing_variant.rs:1:17
@@ -10,4 +11,4 @@ warning: unused import: `AppErrorKind`
 1 | use masterror::{AppErrorKind, Error};
   |                 ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/tests/ui/app_error/fail/missing_code.stderr
+++ b/tests/ui/app_error/fail/missing_code.stderr
@@ -2,7 +2,7 @@ error: AppCode conversion requires `code = ...` in #[app_error(...)]
  --> tests/ui/app_error/fail/missing_code.rs:9:5
   |
 9 |     #[app_error(kind = AppErrorKind::Service)]
-  |     ^
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused imports: `AppCode` and `AppErrorKind`
  --> tests/ui/app_error/fail/missing_code.rs:1:17
@@ -10,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Error};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/tests/ui/app_error/fail/missing_kind.stderr
+++ b/tests/ui/app_error/fail/missing_kind.stderr
@@ -2,4 +2,4 @@ error: missing `kind = ...` in #[app_error(...)]
  --> tests/ui/app_error/fail/missing_kind.rs:5:1
   |
 5 | #[app_error(message)]
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/formatter/fail/duplicate_fmt.stderr
+++ b/tests/ui/formatter/fail/duplicate_fmt.stderr
@@ -2,4 +2,4 @@ error: duplicate `fmt` handler specified
  --> tests/ui/formatter/fail/duplicate_fmt.rs:4:36
   |
 4 | #[error(fmt = crate::format_error, fmt = crate::format_error)]
-  |                                    ^^^
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/formatter/fail/implicit_after_named.stderr
+++ b/tests/ui/formatter/fail/implicit_after_named.stderr
@@ -8,4 +8,5 @@ error: multiple unused formatting arguments
   |                 argument never used
   |                 argument never used
   |
+  = note: consider adding 2 format specifiers
   = note: this error originates in the derive macro `Error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/formatter/fail/unsupported_flag.stderr
+++ b/tests/ui/formatter/fail/unsupported_flag.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..11 uses an unsupported formatter
- --> tests/ui/formatter/fail/unsupported_flag.rs:4:9
+ --> tests/ui/formatter/fail/unsupported_flag.rs:4:10
   |
 4 | #[error("{value:##x}")]
-  |         ^^^^^^^^^^^^^
+  |          ^^^^^^^^^^^

--- a/tests/ui/formatter/fail/unsupported_formatter.stderr
+++ b/tests/ui/formatter/fail/unsupported_formatter.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..9 uses an unsupported formatter
- --> tests/ui/formatter/fail/unsupported_formatter.rs:4:9
+ --> tests/ui/formatter/fail/unsupported_formatter.rs:4:10
   |
 4 | #[error("{value:y}")]
-  |         ^^^^^^^^^^^
+  |          ^^^^^^^^^

--- a/tests/ui/formatter/fail/uppercase_binary.stderr
+++ b/tests/ui/formatter/fail/uppercase_binary.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..9 uses an unsupported formatter
- --> tests/ui/formatter/fail/uppercase_binary.rs:4:9
+ --> tests/ui/formatter/fail/uppercase_binary.rs:4:10
   |
 4 | #[error("{value:B}")]
-  |         ^^^^^^^^^^^
+  |          ^^^^^^^^^

--- a/tests/ui/formatter/fail/uppercase_pointer.stderr
+++ b/tests/ui/formatter/fail/uppercase_pointer.stderr
@@ -1,5 +1,5 @@
 error: placeholder spanning bytes 0..9 uses an unsupported formatter
- --> tests/ui/formatter/fail/uppercase_pointer.rs:4:9
+ --> tests/ui/formatter/fail/uppercase_pointer.rs:4:10
   |
 4 | #[error("{value:P}")]
-  |         ^^^^^^^^^^^
+  |          ^^^^^^^^^

--- a/tests/ui/masterror/fail/duplicate_attr.stderr
+++ b/tests/ui/masterror/fail/duplicate_attr.stderr
@@ -10,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Masterror};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/tests/ui/masterror/fail/duplicate_telemetry.stderr
+++ b/tests/ui/masterror/fail/duplicate_telemetry.stderr
@@ -10,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Masterror};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/tests/ui/masterror/fail/empty_redact.stderr
+++ b/tests/ui/masterror/fail/empty_redact.stderr
@@ -10,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Masterror};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/tests/ui/masterror/fail/enum_missing_variant.stderr
+++ b/tests/ui/masterror/fail/enum_missing_variant.stderr
@@ -1,8 +1,9 @@
 error: all variants must use #[masterror(...)] to derive masterror::Error conversion
  --> tests/ui/masterror/fail/enum_missing_variant.rs:8:5
   |
-8 |     #[error("missing")]
-  |     ^
+8 | /     #[error("missing")]
+9 | |     Missing
+  | |___________^
 
 warning: unused imports: `AppCode` and `AppErrorKind`
  --> tests/ui/masterror/fail/enum_missing_variant.rs:1:17
@@ -10,4 +11,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Masterror};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/tests/ui/masterror/fail/missing_category.stderr
+++ b/tests/ui/masterror/fail/missing_category.stderr
@@ -2,7 +2,7 @@ error: missing `category = ...` in #[masterror(...)]
  --> tests/ui/masterror/fail/missing_category.rs:5:1
   |
 5 | #[masterror(code = AppCode::Internal)]
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused import: `AppCode`
  --> tests/ui/masterror/fail/missing_category.rs:1:17
@@ -10,4 +10,4 @@ warning: unused import: `AppCode`
 1 | use masterror::{AppCode, Masterror};
   |                 ^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/tests/ui/masterror/fail/missing_code.stderr
+++ b/tests/ui/masterror/fail/missing_code.stderr
@@ -2,7 +2,7 @@ error: missing `code = ...` in #[masterror(...)]
  --> tests/ui/masterror/fail/missing_code.rs:5:1
   |
 5 | #[masterror(category = AppErrorKind::Internal)]
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused import: `AppErrorKind`
  --> tests/ui/masterror/fail/missing_code.rs:1:17
@@ -10,4 +10,4 @@ warning: unused import: `AppErrorKind`
 1 | use masterror::{AppErrorKind, Masterror};
   |                 ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/tests/ui/masterror/fail/unknown_option.stderr
+++ b/tests/ui/masterror/fail/unknown_option.stderr
@@ -10,4 +10,4 @@ warning: unused imports: `AppCode` and `AppErrorKind`
 1 | use masterror::{AppCode, AppErrorKind, Masterror};
   |                 ^^^^^^^  ^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default


### PR DESCRIPTION
## Summary
- drop the removed `doc_auto_cfg` feature gate and qualify rustdoc links so documentation builds on the docs.rs nightly toolchain
- refresh trybuild expected stderr outputs to reflect the current compiler diagnostics
- bump the crate to version 0.24.10 and document the change in the changelog and README snippet

## Testing
- cargo +nightly fmt --
- cargo +nightly build --all-targets
- cargo +nightly clippy --all-targets --all-features -- -D warnings
- cargo +nightly test --all
- RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --all-features
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68d9cbe64ca0832b9efb8b75a0f4174d