### PR TITLE
Fix indentation for composite steps in reusable CI workflow

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -168,30 +168,30 @@ jobs:
           delete-branch: true
       # ---------- end README handling ----------
 
-        - name: Check formatting (nightly rustfmt)
-          uses: ./.github/actions/cargo-fmt
-          with:
-            toolchain: nightly
+      - name: Check formatting (nightly rustfmt)
+        uses: ./.github/actions/cargo-fmt
+        with:
+          toolchain: nightly
 
-        - name: Clippy (MSRV)
-          uses: ./.github/actions/cargo-clippy
-          with:
-            toolchain: ${{ steps.msrv.outputs.msrv }}
-            all-features: ${{ inputs.all-features }}
+      - name: Clippy (MSRV)
+        uses: ./.github/actions/cargo-clippy
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv }}
+          all-features: ${{ inputs.all-features }}
 
-        - name: Cargo deny
-          uses: ./.github/actions/cargo-deny
+      - name: Cargo deny
+        uses: ./.github/actions/cargo-deny
 
-        - name: Tests (MSRV)
-          uses: ./.github/actions/cargo-test
-          with:
-            toolchain: ${{ steps.msrv.outputs.msrv }}
-            all-features: ${{ inputs.all-features }}
+      - name: Tests (MSRV)
+        uses: ./.github/actions/cargo-test
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv }}
+          all-features: ${{ inputs.all-features }}
 
-        - name: Security audit
-          uses: ./.github/actions/cargo-audit
+      - name: Security audit
+        uses: ./.github/actions/cargo-audit
 
-        - name: Auto-commit README changes (any branch)
+      - name: Auto-commit README changes (any branch)
         if: always()
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- fix the indentation of the composite cargo steps in the reusable CI workflow so the YAML parses correctly

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy --workspace --all-targets -- -D warnings
- cargo +1.90.0 test --workspace --all-features
- cargo deny check
- cargo audit --deny warnings

------
https://chatgpt.com/codex/tasks/task_e_68db2d2f77fc832b992feb00259507ac