### PR TITLE
Guard std-dependent docs for no_std doc tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.12] - 2025-10-28
+
+### Fixed
+- Gated documentation examples that rely on the standard library and switched
+  the `ErrorResponse` retry example to `core::time::Duration` so docs compile
+  without the `std` feature.
+
 ## [0.24.11] - 2025-10-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.24.11"
+version = "0.24.12"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masterror"
-version = "0.24.11"
+version = "0.24.12"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.24.11", default-features = false }
+masterror = { version = "0.24.12", default-features = false }
 # or with features:
-# masterror = { version = "0.24.11", features = [
+# masterror = { version = "0.24.12", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
@@ -446,4 +446,3 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 ---
 
 MSRV: **1.90** · License: **MIT OR Apache-2.0** · No `unsafe`
-

--- a/src/app_error/context.rs
+++ b/src/app_error/context.rs
@@ -17,6 +17,7 @@ use crate::{AppCode, AppErrorKind};
 /// # Examples
 ///
 /// ```rust
+/// # #[cfg(feature = "std")] {
 /// use std::io::{Error as IoError, ErrorKind};
 ///
 /// use masterror::{AppErrorKind, Context, ResultExt, field};
@@ -36,6 +37,7 @@ use crate::{AppCode, AppErrorKind};
 ///
 /// assert_eq!(err.kind, AppErrorKind::Service);
 /// assert!(err.metadata().get("operation").is_some());
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct Context {

--- a/src/app_error/core.rs
+++ b/src/app_error/core.rs
@@ -460,11 +460,13 @@ impl Error {
     /// # Examples
     ///
     /// ```rust
+    /// # #[cfg(feature = "std")] {
     /// use masterror::AppError;
     ///
     /// let err = AppError::service("downstream degraded")
     ///     .with_context(std::io::Error::new(std::io::ErrorKind::Other, "boom"));
     /// assert!(err.source_ref().is_some());
+    /// # }
     /// ```
     #[must_use]
     pub fn with_context(self, context: impl Into<ContextAttachment>) -> Self {
@@ -495,6 +497,7 @@ impl Error {
     /// # Examples
     ///
     /// ```rust
+    /// # #[cfg(feature = "std")] {
     /// use std::sync::Arc;
     ///
     /// use masterror::{AppError, AppErrorKind};
@@ -503,6 +506,7 @@ impl Error {
     /// let err = AppError::internal("boom").with_source_arc(source.clone());
     /// assert!(err.source_ref().is_some());
     /// assert_eq!(Arc::strong_count(&source), 2);
+    /// # }
     /// ```
     #[must_use]
     pub fn with_source_arc(mut self, source: Arc<dyn CoreError + Send + Sync + 'static>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,11 +230,13 @@
 //!
 //! Attach upstream diagnostics without cloning existing `Arc`s:
 //! ```rust
+//! # #[cfg(feature = "std")] {
 //! use masterror::AppError;
 //!
 //! let err = AppError::internal("db down")
 //!     .with_context(std::io::Error::new(std::io::ErrorKind::Other, "boom"));
 //! assert!(err.source_ref().is_some());
+//! # }
 //! ```
 //!
 //! [`AppErrorKind`] controls the default HTTP status mapping.  

--- a/src/response.rs
+++ b/src/response.rs
@@ -26,7 +26,7 @@
 //! # Example
 //!
 //! ```rust
-//! use std::time::Duration;
+//! use core::time::Duration;
 //!
 //! use masterror::{AppCode, ErrorResponse};
 //!


### PR DESCRIPTION
## Summary
- gate documentation examples that require the standard library so doctests pass without default features
- switch the response retry example to `core::time::Duration` to avoid a `std` dependency
- bump the crate to version 0.24.12, update the changelog, and refresh README guidance

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check
- cargo test --doc --no-default-features
- cargo build
- cargo test readme_is_in_sync


------
https://chatgpt.com/codex/tasks/task_e_68db89175e6c832b8576e60b256e8b3f