### PR TITLE
Fix telemetry test under parallel execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.13] - 2025-10-29
+
+### Fixed
+- Rebuilt the tracing telemetry test to refresh callsite interest so
+  `cargo test --all-features` remains stable under parallel CI execution.
+
 ## [0.24.12] - 2025-10-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.24.12"
+version = "0.24.13"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "masterror"
-version = "0.24.12"
+version = "0.24.13"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/src/app_error/tests.rs
+++ b/src/app_error/tests.rs
@@ -507,7 +507,7 @@ fn telemetry_emits_single_tracing_event_with_trace_id() {
     };
 
     use tracing::{
-        Dispatch, Event, Subscriber, dispatcher,
+        Dispatch, Event, Subscriber, callsite, dispatcher,
         field::{Field, Visit}
     };
     use tracing_subscriber::{
@@ -578,6 +578,7 @@ fn telemetry_emits_single_tracing_event_with_trace_id() {
     let dispatch = Dispatch::new(subscriber);
 
     dispatcher::with_default(&dispatch, || {
+        callsite::rebuild_interest_cache();
         log_mdc::insert("trace_id", "trace-123");
         let err = AppError::internal("boom");
         err.log();


### PR DESCRIPTION
## Summary
- refresh tracing callsite interest before exercising telemetry test to ensure the event is captured when tests run in parallel
- bump the crate version to 0.24.13 and document the fix in the changelog

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy --all-targets --all-features -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all --all-features
- cargo +1.90.0 doc --no-deps
- cargo +1.90.0 audit
- cargo +1.90.0 deny check

------
https://chatgpt.com/codex/tasks/task_e_68dc92717c30832bb368f557354f99ba