### PR TITLE
fix(ci): restore criterion baseline support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.14] - 2025-10-30
+
+### Fixed
+- Declared a dedicated `benchmarks` Cargo feature and disabled the default
+  library benchmark harness so automation can enable Criterion with custom CLI
+  flags, restoring support for `--save-baseline` and other passthrough options
+  in CI.
+- Documented the required feature flag in the README and template to keep local
+  runs aligned with the CI workflow.
+
 ## [0.24.13] - 2025-10-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.24.13"
+version = "0.24.14"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "masterror"
-version = "0.24.13"
+version = "0.24.14"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -78,6 +78,7 @@ frontend = ["dep:wasm-bindgen", "dep:js-sys", "dep:serde-wasm-bindgen", "std"]
 turnkey = ["std"]
 tonic = ["dep:tonic", "std"]
 openapi = ["dep:utoipa", "std"]
+benchmarks = ["std"]
 
 [workspace.dependencies]
 masterror-derive = { version = "0.9.2" }
@@ -182,6 +183,7 @@ feature_order = [
   "tonic",
   "frontend",
   "turnkey",
+  "benchmarks",
 ]
 feature_snippet_group = 4
 conversion_lines = [
@@ -261,5 +263,12 @@ description = "Log to the browser console and convert to JsValue on WASM"
 [package.metadata.masterror.readme.features.turnkey]
 description = "Ship Turnkey-specific error taxonomy and conversions"
 
+[package.metadata.masterror.readme.features.benchmarks]
+description = "Enable Criterion benchmarks and CI baseline tooling"
+extra = [
+  "Primarily used for local profiling and continuous benchmarking runs"
+]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
+bench = false

--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.24.13", default-features = false }
+masterror = { version = "0.24.14", default-features = false }
 # or with features:
-# masterror = { version = "0.24.13", features = [
+# masterror = { version = "0.24.14", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",
 #   "validator", "config", "tokio", "multipart",
 #   "teloxide", "telegram-webapp-sdk", "tonic", "frontend",
-#   "turnkey"
+#   "turnkey", "benchmarks"
 # ] }
 ~~~
 
@@ -100,7 +100,7 @@ Criterion benchmarks cover the hottest conversion paths so regressions are
 visible before shipping. Run them locally with:
 
 ~~~sh
-cargo bench --bench error_paths
+cargo bench -F benchmarks --bench error_paths
 ~~~
 
 The suite emits two groups:
@@ -112,7 +112,7 @@ The suite emits two groups:
   build RFC 7807 payloads via `ProblemJson::from_app_error`, showing how message
   redaction and field policies impact serialization.
 
-Adjust Criterion CLI flags (for example `--sample-size 200`) after `--` to trade
+Adjust Criterion CLI flags (for example `--sample-size 200` or `--save-baseline local`) after `--` to trade
 throughput for tighter confidence intervals when investigating changes.
 
 ---

--- a/README.template.md
+++ b/README.template.md
@@ -95,7 +95,7 @@ Criterion benchmarks cover the hottest conversion paths so regressions are
 visible before shipping. Run them locally with:
 
 ~~~sh
-cargo bench --bench error_paths
+cargo bench -F benchmarks --bench error_paths
 ~~~
 
 The suite emits two groups:
@@ -107,7 +107,7 @@ The suite emits two groups:
   build RFC 7807 payloads via `ProblemJson::from_app_error`, showing how message
   redaction and field policies impact serialization.
 
-Adjust Criterion CLI flags (for example `--sample-size 200`) after `--` to trade
+Adjust Criterion CLI flags (for example `--sample-size 200` or `--save-baseline local`) after `--` to trade
 throughput for tighter confidence intervals when investigating changes.
 
 ---
@@ -447,3 +447,4 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 ---
 
 MSRV: **{{MSRV}}** · License: **MIT OR Apache-2.0** · No `unsafe`
+


### PR DESCRIPTION
## Summary
- add a no-op `benchmarks` feature and disable the library bench harness so the CI bench job can forward Criterion CLI flags
- bump the crate to v0.24.14 and document the new flag in the changelog, README, and template so local runs match automation

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy --all-features -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit
- cargo +1.90.0 bench -F benchmarks --benches -- --save-baseline smoke


------
https://chatgpt.com/codex/tasks/task_e_68dca6c7db8c832b81e9d95a567e7a19