### PR TITLE
Fix ResultExt context handling for non-AppError sources

### DIFF
--- a/src/result_ext.rs
+++ b/src/result_ext.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+use alloc::sync::Arc;
 use core::error::Error as CoreError;
 
 use crate::app_error::{Context, Error};
@@ -84,10 +85,10 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
 
             match source.downcast::<Error>() {
                 Ok(app_err) => {
-                    let mut app_err = *app_err;
+                    let app_err = *app_err;
                     let mut enriched = Error::new_raw(app_err.kind, Some(msg.clone()));
 
-                    enriched.code = app_err.code;
+                    enriched.code = app_err.code.clone();
                     enriched.metadata = app_err.metadata.clone();
                     enriched.edit_policy = app_err.edit_policy;
                     enriched.retry = app_err.retry;
@@ -107,7 +108,7 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
 
                     enriched.with_context(app_err)
                 }
-                Err(source) => Error::internal(msg.clone()).with_context(source)
+                Err(source) => Error::internal(msg.clone()).with_source_arc(Arc::from(source))
             }
         })
     }


### PR DESCRIPTION
## Summary
- convert non-AppError sources to `Arc` before attaching them as context so `Error::with_context` accepts them
- clone only the necessary fields when enriching existing `Error` instances to avoid partial moves

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68e1e71d4b00832bb4677e88827bf7a6