### PR TITLE
Preserve AppError backtraces when applying context wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.17] - 2025-11-02
+
+### Fixed
+- Preserve captured backtraces when wrapping `AppError` instances through
+  `ResultExt::context` by sharing the snapshot instead of attempting to clone
+  `std::backtrace::Backtrace`.
+
 ## [0.24.16] - 2025-11-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "masterror"
-version = "0.24.16"
+version = "0.24.17"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "masterror"
-version = "0.24.16"
+version = "0.24.17"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.24.16", default-features = false }
+masterror = { version = "0.24.17", default-features = false }
 # or with features:
-# masterror = { version = "0.24.16", features = [
+# masterror = { version = "0.24.17", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "sqlx", "sqlx-migrate", "reqwest", "redis",

--- a/src/result_ext.rs
+++ b/src/result_ext.rs
@@ -102,8 +102,11 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
                         enriched.details = app_err.details.clone();
                     }
                     #[cfg(feature = "backtrace")]
-                    if let Some(backtrace) = app_err.backtrace().cloned() {
-                        enriched = enriched.with_backtrace(backtrace);
+                    let shared_backtrace = app_err.backtrace_shared();
+
+                    #[cfg(feature = "backtrace")]
+                    if let Some(backtrace) = shared_backtrace {
+                        enriched = enriched.with_shared_backtrace(backtrace);
                     }
 
                     enriched.with_context(app_err)


### PR DESCRIPTION
## Summary
- store captured backtraces on `AppError` using shared `Arc` snapshots so existing traces can be reused without cloning
- update `ResultExt::context` to reuse the shared backtrace when wrapping an existing `AppError`
- bump the crate version to 0.24.17 and document the fix in the changelog and README

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check


------
https://chatgpt.com/codex/tasks/task_e_68e1ed19b024832b924720b66758db9c