### PR TITLE
217

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -439,16 +439,11 @@ jobs:
         run: |
           cargo llvm-cov nextest --profile ci --all-features --workspace --lcov --output-path lcov.info
 
-      - name: Generate HTML coverage report
-        run: cargo llvm-cov --all-features --workspace --html
-
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
-          path: |
-            lcov.info
-            target/llvm-cov/html/
+          path: lcov.info
           retention-days: 30
 
       - name: Add generation summary
@@ -456,7 +451,6 @@ jobs:
           echo "## Coverage Generation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- LCOV report: \`lcov.info\`" >> $GITHUB_STEP_SUMMARY
-          echo "- HTML report: \`target/llvm-cov/html/\`" >> $GITHUB_STEP_SUMMARY
           echo "- Saved as artifact for Codecov upload" >> $GITHUB_STEP_SUMMARY
 
   upload-coverage:


### PR DESCRIPTION
## Summary

Fixed cargo-llvm-cov HTML generation conflict that caused CI failures after #216 merge.

## Changes

- Removed "Generate HTML coverage report" step from `generate-coverage` job
- Removed `target/llvm-cov/html/` from artifact upload path
- Updated generation summary to reflect LCOV-only output

## Problem

After merging #216, the `generate-coverage` job was failing because we ran two conflicting commands:
1. `cargo llvm-cov nextest --profile ci --lcov` - generates coverage with nextest
2. `cargo llvm-cov --html` - tries to regenerate coverage WITHOUT nextest

This caused the second command to fail.

## Solution

HTML coverage reports are only needed for local development. Codecov provides its own web interface, so we only need to upload `lcov.info` from CI.

## Related

- Closes #217
- Related to #213, #215
- Fixes CI failure introduced in PR #216

## Test Plan

- [x] CI should complete successfully on this branch
- [x] Coverage data should upload correctly to Codecov
- [x] No regression in test execution