### PR TITLE
219

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ SPDX-License-Identifier: MIT
 [![Downloads](https://img.shields.io/crates/d/masterror)](https://crates.io/crates/masterror)
 ![MSRV](https://img.shields.io/badge/MSRV-1.90-blue)
 ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
+[![codecov](https://codecov.io/gh/RAprogramm/masterror/graph/badge.svg?token=V9JQDTZLXH)](https://codecov.io/gh/RAprogramm/masterror)
+
 [![CI](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 [![Security audit](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main&label=Security%20audit)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 [![Cargo Deny](https://img.shields.io/github/actions/workflow/status/RAprogramm/masterror/ci.yml?branch=main&label=Cargo%20Deny)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
-[![codecov](https://codecov.io/gh/RAprogramm/masterror/graph/badge.svg?token=V9JQDTZLXH)](https://codecov.io/gh/RAprogramm/masterror)
 
 > 🇷🇺 Читайте README на [русском языке](README.ru.md).
 
@@ -120,7 +121,7 @@ throughput for tighter confidence intervals when investigating changes.
 
 ### Code Coverage
 
-[![codecov](https://codecov.io/gh/RAprogramm/masterror/branch/main/graph/badge.svg?token=OD4F7LWWB8)](https://app.codecov.io/gh/RAprogramm/masterror)
+[![codecov](https://codecov.io/gh/RAprogramm/masterror/branch/main/graph/badge.svg?token=V9JQDTZLXH)](https://app.codecov.io/gh/RAprogramm/masterror)
 
 Coverage reports are automatically generated on every CI run and uploaded to [Codecov](https://app.codecov.io/gh/RAprogramm/masterror). The project maintains high test coverage across all modules to ensure reliability and catch regressions early.
 
@@ -130,17 +131,17 @@ Coverage reports are automatically generated on every CI run and uploaded to [Co
 #### Sunburst Graph
 The inner-most circle represents the entire project, moving outward through folders to individual files. Size and color indicate statement count and coverage percentage.
 
-[![Sunburst](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/sunburst.svg?token=OD4F7LWWB8)](https://app.codecov.io/gh/RAprogramm/masterror)
+[![Sunburst](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/sunburst.svg?token=V9JQDTZLXH)](https://app.codecov.io/gh/RAprogramm/masterror)
 
 #### Grid View
 Each block represents a single file. Block size and color correspond to statement count and coverage percentage.
 
-[![Grid](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/tree.svg?token=OD4F7LWWB8)](https://app.codecov.io/gh/RAprogramm/masterror)
+[![Grid](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/tree.svg?token=V9JQDTZLXH)](https://app.codecov.io/gh/RAprogramm/masterror)
 
 #### Icicle Chart
 Hierarchical view starting with the entire project at the top, drilling down through folders to individual files. Size and color reflect statement count and coverage.
 
-[![Icicle](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/icicle.svg?token=OD4F7LWWB8)](https://app.codecov.io/gh/RAprogramm/masterror)
+[![Icicle](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/icicle.svg?token=V9JQDTZLXH)](https://app.codecov.io/gh/RAprogramm/masterror)
 
 </details>
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,10 +13,11 @@ SPDX-License-Identifier: MIT
 [![Downloads](https://img.shields.io/crates/d/masterror)](https://crates.io/crates/masterror)
 ![MSRV](https://img.shields.io/badge/MSRV-1.90-blue)
 ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
+[![codecov](https://codecov.io/gh/RAprogramm/masterror/graph/badge.svg?token=V9JQDTZLXH)](https://codecov.io/gh/RAprogramm/masterror)
+
 [![CI](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 [![Security audit](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main&label=Security%20audit)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 [![Cargo Deny](https://img.shields.io/github/actions/workflow/status/RAprogramm/masterror/ci.yml?branch=main&label=Cargo%20Deny)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
-[![codecov](https://codecov.io/gh/RAprogramm/masterror/graph/badge.svg?token=OD4F7LWWB8)](https://codecov.io/gh/RAprogramm/masterror)
 
 `masterror` вырос из набора вспомогательных функций в полноценный workspace с
 модульными крейтами для построения наблюдаемых и последовательных ошибок в

--- a/README.template.md
+++ b/README.template.md
@@ -14,10 +14,11 @@ SPDX-License-Identifier: MIT
 [![Downloads](https://img.shields.io/crates/d/masterror)](https://crates.io/crates/masterror)
 ![MSRV](https://img.shields.io/badge/MSRV-{{MSRV}}-blue)
 ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
+[![codecov](https://codecov.io/gh/RAprogramm/masterror/graph/badge.svg?token=V9JQDTZLXH)](https://codecov.io/gh/RAprogramm/masterror)
+
 [![CI](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 [![Security audit](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main&label=Security%20audit)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
 [![Cargo Deny](https://img.shields.io/github/actions/workflow/status/RAprogramm/masterror/ci.yml?branch=main&label=Cargo%20Deny)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)
-[![codecov](https://codecov.io/gh/RAprogramm/masterror/branch/main/graph/badge.svg?token=OD4F7LWWB8)](https://app.codecov.io/gh/RAprogramm/masterror)
 
 > 🇷🇺 Читайте README на [русском языке](README.ru.md).
 
@@ -115,7 +116,7 @@ throughput for tighter confidence intervals when investigating changes.
 
 ### Code Coverage
 
-[![codecov](https://codecov.io/gh/RAprogramm/masterror/branch/main/graph/badge.svg?token=OD4F7LWWB8)](https://app.codecov.io/gh/RAprogramm/masterror)
+[![codecov](https://codecov.io/gh/RAprogramm/masterror/branch/main/graph/badge.svg?token=V9JQDTZLXH)](https://app.codecov.io/gh/RAprogramm/masterror)
 
 Coverage reports are automatically generated on every CI run and uploaded to [Codecov](https://app.codecov.io/gh/RAprogramm/masterror). The project maintains high test coverage across all modules to ensure reliability and catch regressions early.
 
@@ -125,17 +126,17 @@ Coverage reports are automatically generated on every CI run and uploaded to [Co
 #### Sunburst Graph
 The inner-most circle represents the entire project, moving outward through folders to individual files. Size and color indicate statement count and coverage percentage.
 
-[![Sunburst](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/sunburst.svg?token=OD4F7LWWB8)](https://app.codecov.io/gh/RAprogramm/masterror)
+[![Sunburst](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/sunburst.svg?token=V9JQDTZLXH)](https://app.codecov.io/gh/RAprogramm/masterror)
 
 #### Grid View
 Each block represents a single file. Block size and color correspond to statement count and coverage percentage.
 
-[![Grid](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/tree.svg?token=OD4F7LWWB8)](https://app.codecov.io/gh/RAprogramm/masterror)
+[![Grid](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/tree.svg?token=V9JQDTZLXH)](https://app.codecov.io/gh/RAprogramm/masterror)
 
 #### Icicle Chart
 Hierarchical view starting with the entire project at the top, drilling down through folders to individual files. Size and color reflect statement count and coverage.
 
-[![Icicle](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/icicle.svg?token=OD4F7LWWB8)](https://app.codecov.io/gh/RAprogramm/masterror)
+[![Icicle](https://codecov.io/gh/RAprogramm/masterror/branch/main/graphs/icicle.svg?token=V9JQDTZLXH)](https://app.codecov.io/gh/RAprogramm/masterror)
 
 </details>
 


### PR DESCRIPTION
## Summary

Updated Codecov badge token and reorganized badges into 2 professional rows across all README files.

## Changes

### Badge Reorganization
**Row 1 (Project metrics)**:
- Crates.io version
- docs.rs documentation
- Download stats
- MSRV
- License
- **Codecov coverage**

**Row 2 (Infrastructure)**:
- CI status
- Security audit
- Cargo Deny

### Token Update
- Updated Codecov token from `OD4F7LWWB8` to `V9JQDTZLXH` in all locations:
  - README.template.md (5 occurrences)
  - README.ru.md
  - README.md (auto-generated)

### Files Modified
- `README.template.md` - source template with new layout and token
- `README.ru.md` - Russian version with same layout
- `README.md` - auto-generated from template via `cargo build`

## Why This Matters

The old token prevented Codecov badges from displaying coverage data correctly. The new 2-row layout provides better visual hierarchy:
- **First glance**: Project quality (version, docs, coverage)
- **Second row**: Development infrastructure status

## Related

- Closes #219
- Related to #217 (Codecov integration fix)

## Test Plan

- [x] Badges render correctly in GitHub UI
- [x] Codecov badge displays coverage with new token
- [x] Layout is professional and easy to scan
- [x] All 3 README files updated consistently
