### PR TITLE
227

### DIFF
--- a/src/response/axum_impl.rs
+++ b/src/response/axum_impl.rs
@@ -59,3 +59,144 @@ impl IntoResponse for ErrorResponse {
         ProblemJson::from_error_response(self).into_response()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        http::{
+            StatusCode,
+            header::{CONTENT_TYPE, RETRY_AFTER, WWW_AUTHENTICATE}
+        },
+        response::IntoResponse
+    };
+
+    use crate::{AppCode, AppError, ErrorResponse, ProblemJson, response::core::RetryAdvice};
+
+    #[tokio::test]
+    async fn problem_json_into_response_sets_status_and_content_type() {
+        let problem = ProblemJson::from_app_error(AppError::not_found("resource not found"));
+        let response = problem.into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(content_type, Some("application/problem+json"));
+    }
+
+    #[tokio::test]
+    async fn problem_json_into_response_includes_retry_after_header() {
+        let error = AppError::rate_limited("too many requests").with_retry_after_secs(120);
+        let problem = ProblemJson::from_app_error(error);
+        let response = problem.into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let retry = response
+            .headers()
+            .get(RETRY_AFTER)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(retry, Some("120"));
+    }
+
+    #[tokio::test]
+    async fn problem_json_into_response_includes_www_authenticate_header() {
+        let error = AppError::unauthorized("invalid credentials")
+            .with_www_authenticate("Basic realm=\"api\"");
+        let problem = ProblemJson::from_app_error(error);
+        let response = problem.into_response();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let auth = response
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(auth, Some("Basic realm=\"api\""));
+    }
+
+    #[tokio::test]
+    async fn problem_json_into_response_includes_both_retry_and_auth_headers() {
+        let error = AppError::rate_limited("rate limited")
+            .with_retry_after_secs(90)
+            .with_www_authenticate("Bearer");
+        let problem = ProblemJson::from_app_error(error);
+        let response = problem.into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let retry = response
+            .headers()
+            .get(RETRY_AFTER)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(retry, Some("90"));
+        let auth = response
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(auth, Some("Bearer"));
+    }
+
+    #[tokio::test]
+    async fn error_response_into_response_converts_correctly() {
+        let error_response =
+            ErrorResponse::new(500, AppCode::Internal, "internal error").expect("valid status");
+        let response = error_response.into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(content_type, Some("application/problem+json"));
+    }
+
+    #[tokio::test]
+    async fn error_response_into_response_with_retry_header() {
+        let mut error_response = ErrorResponse::new(503, AppCode::Service, "service unavailable")
+            .expect("valid status");
+        error_response.retry = Some(RetryAdvice {
+            after_seconds: 300
+        });
+        let response = error_response.into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let retry = response
+            .headers()
+            .get(RETRY_AFTER)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(retry, Some("300"));
+    }
+
+    #[tokio::test]
+    async fn error_response_into_response_with_www_authenticate() {
+        let mut error_response =
+            ErrorResponse::new(401, AppCode::Unauthorized, "auth required").expect("valid status");
+        error_response.www_authenticate = Some("Digest realm=\"api\"".to_owned());
+        let response = error_response.into_response();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let auth = response
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(auth, Some("Digest realm=\"api\""));
+    }
+
+    #[tokio::test]
+    async fn problem_json_into_response_handles_various_status_codes() {
+        let test_cases = vec![
+            (AppError::bad_request("bad"), StatusCode::BAD_REQUEST),
+            (AppError::conflict("conflict"), StatusCode::CONFLICT),
+            (AppError::forbidden("forbidden"), StatusCode::FORBIDDEN),
+            (
+                AppError::internal("internal"),
+                StatusCode::INTERNAL_SERVER_ERROR
+            ),
+        ];
+
+        for (error, expected_status) in test_cases {
+            let problem = ProblemJson::from_app_error(error);
+            let response = problem.into_response();
+            assert_eq!(response.status(), expected_status);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Added comprehensive test coverage for `src/response/axum_impl.rs`.

## Tests Added

- Status code and Content-Type verification
- Retry-After header handling
- WWW-Authenticate header handling
- Combined retry and auth headers
- ErrorResponse IntoResponse implementation
- ErrorResponse with retry header
- ErrorResponse with www_authenticate header
- Multiple status code scenarios

## Coverage

8 tests covering all IntoResponse implementations and header handling.

Closes #227