### PR TITLE
228

### DIFF
--- a/src/response/core.rs
+++ b/src/response/core.rs
@@ -104,3 +104,141 @@ impl ErrorResponse {
     }
 }
 use alloc::{format, string::String};
+
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
+
+    use super::*;
+
+    #[test]
+    fn new_creates_error_response_with_valid_status() {
+        let result = ErrorResponse::new(404, AppCode::NotFound, "missing");
+        assert!(result.is_ok());
+        let resp = result.unwrap();
+        assert_eq!(resp.status, 404);
+        assert_eq!(resp.code, AppCode::NotFound);
+        assert_eq!(resp.message, "missing");
+        assert!(resp.details.is_none());
+        assert!(resp.retry.is_none());
+        assert!(resp.www_authenticate.is_none());
+    }
+
+    #[test]
+    fn new_rejects_invalid_http_status_code() {
+        let result = ErrorResponse::new(1000, AppCode::Internal, "bad status");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, crate::AppErrorKind::BadRequest);
+    }
+
+    #[test]
+    fn new_accepts_string_types() {
+        let owned = ErrorResponse::new(200, AppCode::Internal, String::from("owned"));
+        assert!(owned.is_ok());
+
+        let borrowed = ErrorResponse::new(201, AppCode::Internal, "borrowed");
+        assert!(borrowed.is_ok());
+    }
+
+    #[test]
+    fn status_code_converts_valid_status() {
+        let resp = ErrorResponse::new(404, AppCode::NotFound, "test").unwrap();
+        assert_eq!(resp.status_code(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn status_code_defaults_to_internal_server_error_for_invalid() {
+        let mut resp = ErrorResponse::new(200, AppCode::Internal, "test").unwrap();
+        resp.status = 1000; // Manually set invalid status (HTTP codes are 100-999)
+        assert_eq!(resp.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn retry_advice_fields_are_accessible() {
+        let advice = RetryAdvice {
+            after_seconds: 60
+        };
+        assert_eq!(advice.after_seconds, 60);
+    }
+
+    #[test]
+    fn retry_advice_supports_copy_and_equality() {
+        let advice1 = RetryAdvice {
+            after_seconds: 30
+        };
+        let advice2 = advice1; // Copy, not clone
+        assert_eq!(advice1, advice2);
+    }
+
+    #[test]
+    fn error_response_supports_clone() {
+        let resp1 = ErrorResponse::new(500, AppCode::Internal, "error").unwrap();
+        let resp2 = resp1.clone();
+        assert_eq!(resp1.status, resp2.status);
+        assert_eq!(resp1.code, resp2.code);
+        assert_eq!(resp1.message, resp2.message);
+    }
+
+    #[test]
+    fn error_response_with_retry_advice() {
+        let mut resp = ErrorResponse::new(429, AppCode::RateLimited, "too many").unwrap();
+        resp.retry = Some(RetryAdvice {
+            after_seconds: 120
+        });
+        assert!(resp.retry.is_some());
+        assert_eq!(resp.retry.unwrap().after_seconds, 120);
+    }
+
+    #[test]
+    fn error_response_with_www_authenticate() {
+        let mut resp = ErrorResponse::new(401, AppCode::Unauthorized, "auth required").unwrap();
+        resp.www_authenticate = Some("Bearer realm=\"api\"".to_owned());
+        assert!(resp.www_authenticate.is_some());
+        assert_eq!(
+            resp.www_authenticate.as_deref(),
+            Some("Bearer realm=\"api\"")
+        );
+    }
+
+    #[cfg(feature = "serde_json")]
+    #[test]
+    fn error_response_with_json_details() {
+        use serde_json::json;
+        let mut resp = ErrorResponse::new(422, AppCode::Validation, "invalid").unwrap();
+        resp.details = Some(json!({"field": "email", "error": "invalid format"}));
+        assert!(resp.details.is_some());
+    }
+
+    #[cfg(not(feature = "serde_json"))]
+    #[test]
+    fn error_response_with_text_details() {
+        let mut resp = ErrorResponse::new(422, AppCode::Validation, "invalid").unwrap();
+        resp.details = Some("Field validation failed".to_owned());
+        assert!(resp.details.is_some());
+        assert_eq!(resp.details.as_deref(), Some("Field validation failed"));
+    }
+
+    #[test]
+    fn common_http_status_codes_work() {
+        let codes = vec![
+            (200, StatusCode::OK),
+            (201, StatusCode::CREATED),
+            (400, StatusCode::BAD_REQUEST),
+            (401, StatusCode::UNAUTHORIZED),
+            (403, StatusCode::FORBIDDEN),
+            (404, StatusCode::NOT_FOUND),
+            (422, StatusCode::UNPROCESSABLE_ENTITY),
+            (429, StatusCode::TOO_MANY_REQUESTS),
+            (500, StatusCode::INTERNAL_SERVER_ERROR),
+            (502, StatusCode::BAD_GATEWAY),
+            (503, StatusCode::SERVICE_UNAVAILABLE),
+            (504, StatusCode::GATEWAY_TIMEOUT),
+        ];
+
+        for (num, expected) in codes {
+            let resp = ErrorResponse::new(num, AppCode::Internal, "test").unwrap();
+            assert_eq!(resp.status_code(), expected);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Added comprehensive test coverage for `src/response/core.rs` (issue #228).

## Changes

Implemented 12 tests covering all core functionality:
- `ErrorResponse::new()` constructor with HTTP status validation  
- `StatusCode` conversion and fallback to `INTERNAL_SERVER_ERROR`
- String type acceptance (owned `String` and borrowed `&str`)
- `RetryAdvice` struct fields and traits (Copy, PartialEq)
- `ErrorResponse` Clone trait implementation
- Optional fields: `retry`, `www_authenticate`, `details` (JSON/text)
- Common HTTP status codes validation (200-504 range)
- Invalid status code rejection (≥1000)

## Test Coverage

All 12 unit tests pass successfully:
- `new_creates_error_response_with_valid_status`
- `new_rejects_invalid_http_status_code`
- `new_accepts_string_types`
- `status_code_converts_valid_status`
- `status_code_defaults_to_internal_server_error_for_invalid`
- `retry_advice_fields_are_accessible`
- `retry_advice_supports_copy_and_equality`
- `error_response_supports_clone`
- `error_response_with_retry_advice`
- `error_response_with_www_authenticate`
- `error_response_with_json_details` (serde_json feature)
- `common_http_status_codes_work`

## Test Plan

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-features --all-targets` passes  
- [x] `cargo test --all-features --lib` - all 12 tests pass
- [x] Pre-commit hooks pass (fmt, clippy, tests)

---

Closes #228
