### PR TITLE
254

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -303,8 +303,7 @@ jobs:
               --base main \
               --head "$BR" \
               --title "chore(readme): auto-refresh" \
-              --body "Автоматически сгенерированный апдейт README. Прямой пуш в \`main\` запрещён политикой, поэтому открыт PR." \
-              --label ci,chore || echo "Failed to create PR, it may already exist"
+              --body "Автоматически сгенерированный апдейт README. Прямой пуш в \`main\` запрещён политикой, поэтому открыт PR."
           fi
 
       - name: Tests with nextest (${{ matrix.rust }})


### PR DESCRIPTION
## Summary

Fixed auto-refresh workflow that was creating orphaned `ci/readme-auto-refresh` branches due to silent PR creation failures.

## Problem

Workflow was creating `ci/readme-auto-refresh` branch but **not creating PR** because:
1. `gh pr create --label ci,chore` failed (labels don't exist)
2. `|| echo "Failed..."` suppressed the error
3. Branch remained without PR
4. Auto-delete never triggered (no merge happened)

## Solution

Removed problematic parts:
- ❌ `--label ci,chore` (labels don't exist in repo)
- ❌ `|| echo "Failed..."` (masks errors)

Now workflow will:
- ✅ Create PR successfully every time
- ✅ Auto-delete branch after merge (GitHub setting enabled)
- ✅ Fail loudly if something goes wrong

## Test Plan

- [x] Workflow YAML syntax valid
- [x] All tests pass
- [x] Clippy passes
- [x] Verified labels don't exist: `gh label list | grep -E '(ci|chore)'` → empty
- [x] Deleted existing orphaned branch: `ci/readme-auto-refresh`

## Expected Behavior

Next time README needs auto-refresh:
1. Workflow creates branch `ci/readme-auto-refresh` ✓
2. PR created successfully (no label error) ✓
3. After merge, branch auto-deleted by GitHub ✓

Closes #254