### PR TITLE
265

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ of redaction and metadata.
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -94,7 +94,7 @@ of redaction and metadata.
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -114,7 +114,7 @@ of redaction and metadata.
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -142,7 +142,7 @@ The build script keeps the full feature snippet below in sync with
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -170,7 +170,7 @@ masterror = { version = "0.24.19", default-features = false }
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -203,7 +203,7 @@ throughput for tighter confidence intervals when investigating changes.
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -241,7 +241,7 @@ Hierarchical view starting with the entire project at the top, drilling down thr
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -289,7 +289,7 @@ fn do_work(flag: bool) -> AppResult<()> {
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -593,7 +593,7 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -614,7 +614,7 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -630,7 +630,7 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -642,6 +642,5 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 ## License
 
 MSRV: **1.90** · License: **MIT OR Apache-2.0** · No `unsafe`
-
 
 

--- a/README.template.md
+++ b/README.template.md
@@ -57,7 +57,7 @@ of redaction and metadata.
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -94,7 +94,7 @@ of redaction and metadata.
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -114,7 +114,7 @@ of redaction and metadata.
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -142,7 +142,7 @@ The build script keeps the full feature snippet below in sync with
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -165,7 +165,7 @@ masterror = { version = "{{CRATE_VERSION}}", default-features = false }
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -198,7 +198,7 @@ throughput for tighter confidence intervals when investigating changes.
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -236,7 +236,7 @@ Hierarchical view starting with the entire project at the top, drilling down thr
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -284,7 +284,7 @@ fn do_work(flag: bool) -> AppResult<()> {
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -588,7 +588,7 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -609,7 +609,7 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>
@@ -625,7 +625,7 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 <div align="right">
 
 <div align="right">
-  <a href="#-table-of-contents">
+  <a href="#table-of-contents">
     <img src="https://raw.githubusercontent.com/RAprogramm/masterror/main/images/masterror_go_to_top.png" alt="Go to top" width="50"/>
   </a>
 </div>


### PR DESCRIPTION
Fixes broken 'go to top' navigation links throughout README.

## Changes

Updated all 'go to top' links from `#-table-of-contents` to `#table-of-contents`.

## Root Cause  

The Table of Contents header doesn't contain an emoji, so GitHub generates the anchor as `#table-of-contents` (not `#-table-of-contents`).

## Testing

All 11 'go to top' buttons now correctly jump to the Table of Contents section.

Closes #265