### PR TITLE
#300 feat: add REUSE license compliance check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 ---
 name: Bug Report
 about: Report a bug or unexpected behavior

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 ---
 name: Documentation Improvement
 about: Suggest improvements to documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 ---
 name: Feature Request
 about: Suggest a new feature or enhancement

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -94,6 +94,24 @@ jobs:
         with:
           toolchain: nightly
 
+  reuse:
+    runs-on: ubuntu-latest
+    needs: fmt
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install reuse tool
+        shell: bash
+        run: |
+          pip install --user reuse
+
+      - name: Check REUSE compliance
+        shell: bash
+        run: |
+          reuse lint
+
   clippy:
     runs-on: ubuntu-latest
     needs: msrv
@@ -160,7 +178,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [msrv, fmt, clippy]
+    needs: [msrv, fmt, reuse, clippy]
     permissions:
       contents: write
       pull-requests: write

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -10,6 +10,16 @@ rustup component add rustfmt --toolchain nightly >/dev/null
 echo "🧹 Checking formatting with rustfmt..."
 cargo +nightly fmt --all -- --check
 
+echo "📜 Checking REUSE compliance..."
+if command -v reuse &> /dev/null; then
+    reuse lint
+else
+    echo "⚠️  Warning: reuse tool not installed, skipping license compliance check"
+    echo "   Install with:"
+    echo "   - Arch Linux: paru -S reuse (or sudo pacman -S reuse)"
+    echo "   - pip:        pip install reuse"
+fi
+
 echo "🔍 Running clippy (all features, all targets)..."
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ SPDX-License-Identifier: MIT
   [![Downloads](https://img.shields.io/crates/d/masterror)](https://crates.io/crates/masterror)
   ![MSRV](https://img.shields.io/badge/MSRV-1.90-blue)
   ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
+  [![REUSE status](https://api.reuse.software/badge/github.com/RAprogramm/masterror)](https://api.reuse.software/info/github.com/RAprogramm/masterror)
   [![codecov](https://codecov.io/gh/RAprogramm/masterror/graph/badge.svg?token=V9JQDTZLXH)](https://codecov.io/gh/RAprogramm/masterror)
 
   [![CI](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)

--- a/README.template.md
+++ b/README.template.md
@@ -16,6 +16,7 @@ SPDX-License-Identifier: MIT
   [![Downloads](https://img.shields.io/crates/d/masterror)](https://crates.io/crates/masterror)
   ![MSRV](https://img.shields.io/badge/MSRV-{{MSRV}}-blue)
   ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
+  [![REUSE status](https://api.reuse.software/badge/github.com/RAprogramm/masterror)](https://api.reuse.software/info/github.com/RAprogramm/masterror)
   [![codecov](https://codecov.io/gh/RAprogramm/masterror/graph/badge.svg?token=V9JQDTZLXH)](https://codecov.io/gh/RAprogramm/masterror)
 
   [![CI](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/masterror/actions/workflows/ci.yml?query=branch%3Amain)

--- a/images/masterror_go_to_top.png.license
+++ b/images/masterror_go_to_top.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/images/materror.png.license
+++ b/images/materror.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/masterror-derive/README.md
+++ b/masterror-derive/README.md
@@ -6,6 +6,8 @@ SPDX-License-Identifier: MIT
 
 # masterror-derive
 
+[![REUSE status](https://api.reuse.software/badge/github.com/RAprogramm/masterror)](https://api.reuse.software/info/github.com/RAprogramm/masterror)
+
 Procedural macros that power [`masterror`](https://crates.io/crates/masterror)'s
 `#[derive(Error)]`. The derive generates ergonomic `std::error::Error` and
 `Display` implementations together with seamless integration into

--- a/masterror-template/README.md
+++ b/masterror-template/README.md
@@ -6,6 +6,8 @@ SPDX-License-Identifier: MIT
 
 # masterror-template
 
+[![REUSE status](https://api.reuse.software/badge/github.com/RAprogramm/masterror)](https://api.reuse.software/info/github.com/RAprogramm/masterror)
+
 `masterror-template` packages the template parser shared by the [`masterror`][masterror] runtime crate and the [`masterror-derive`][derive] procedural macros. It understands the `#[error("...")]` formatting language popularised by `thiserror` v2, producing a structured representation that downstream code can inspect or render.
 
 The crate is intentionally small: it exposes just enough API for advanced applications that want to inspect derived error displays, implement custom derive helpers, or perform static analysis over formatting placeholders.

--- a/tests/ui/app_error/fail/enum_missing_variant.stderr.license
+++ b/tests/ui/app_error/fail/enum_missing_variant.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/app_error/fail/missing_code.stderr.license
+++ b/tests/ui/app_error/fail/missing_code.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/app_error/fail/missing_kind.stderr.license
+++ b/tests/ui/app_error/fail/missing_kind.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/backtrace/duplicate.stderr.license
+++ b/tests/ui/backtrace/duplicate.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/backtrace/invalid_type.stderr.license
+++ b/tests/ui/backtrace/invalid_type.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/formatter/fail/duplicate_fmt.stderr.license
+++ b/tests/ui/formatter/fail/duplicate_fmt.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/formatter/fail/duplicate_named_arguments.stderr.license
+++ b/tests/ui/formatter/fail/duplicate_named_arguments.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/formatter/fail/implicit_after_named.stderr.license
+++ b/tests/ui/formatter/fail/implicit_after_named.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/formatter/fail/transparent_fmt.stderr.license
+++ b/tests/ui/formatter/fail/transparent_fmt.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/formatter/fail/unsupported_flag.stderr.license
+++ b/tests/ui/formatter/fail/unsupported_flag.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/formatter/fail/unsupported_formatter.stderr.license
+++ b/tests/ui/formatter/fail/unsupported_formatter.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/formatter/fail/uppercase_binary.stderr.license
+++ b/tests/ui/formatter/fail/uppercase_binary.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/formatter/fail/uppercase_pointer.stderr.license
+++ b/tests/ui/formatter/fail/uppercase_pointer.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/from/struct_multiple_fields.stderr.license
+++ b/tests/ui/from/struct_multiple_fields.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/from/variant_multiple_fields.stderr.license
+++ b/tests/ui/from/variant_multiple_fields.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/masterror/fail/duplicate_attr.stderr.license
+++ b/tests/ui/masterror/fail/duplicate_attr.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/masterror/fail/duplicate_telemetry.stderr.license
+++ b/tests/ui/masterror/fail/duplicate_telemetry.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/masterror/fail/empty_redact.stderr.license
+++ b/tests/ui/masterror/fail/empty_redact.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/masterror/fail/enum_missing_variant.stderr.license
+++ b/tests/ui/masterror/fail/enum_missing_variant.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/masterror/fail/missing_attr.stderr.license
+++ b/tests/ui/masterror/fail/missing_attr.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/masterror/fail/missing_category.stderr.license
+++ b/tests/ui/masterror/fail/missing_category.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/masterror/fail/missing_code.stderr.license
+++ b/tests/ui/masterror/fail/missing_code.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/masterror/fail/unknown_option.stderr.license
+++ b/tests/ui/masterror/fail/unknown_option.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/transparent/arguments_not_supported.stderr.license
+++ b/tests/ui/transparent/arguments_not_supported.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/transparent/enum_variant_multiple_fields.stderr.license
+++ b/tests/ui/transparent/enum_variant_multiple_fields.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/transparent/enum_variant_no_fields.stderr.license
+++ b/tests/ui/transparent/enum_variant_no_fields.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/transparent/struct_multiple_fields.stderr.license
+++ b/tests/ui/transparent/struct_multiple_fields.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT

--- a/tests/ui/transparent/struct_no_fields.stderr.license
+++ b/tests/ui/transparent/struct_no_fields.stderr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+
+SPDX-License-Identifier: MIT


### PR DESCRIPTION
## Summary
- Add reuse lint job to GitHub Actions workflow after fmt check
- Add reuse lint to pre-commit hook (.hooks/pre-commit)
- Add REUSE compliance badge to all README files
- Add SPDX headers to issue templates
- Create .license files for images and test stderr files
- Project now 100% REUSE compliant (225/225 files)

## Changes

### CI/CD Integration
- Added `reuse` job to `.github/workflows/reusable-ci.yml` after `fmt` check
- Job installs reuse tool via pip and runs `reuse lint`
- Added `reuse` to test job dependencies

### Pre-commit Hook
- Added reuse lint check to `.hooks/pre-commit` after formatting
- Includes fallback with installation instructions for Arch Linux (paru/pacman) and pip

### REUSE Badges
- Added badge to `README.template.md` (root)
- Added badge to `masterror-derive/README.md`
- Added badge to `masterror-template/README.md`

### License Compliance
- Added SPDX headers to 3 issue template markdown files
- Created 30 `.license` files:
  - 2 PNG images
  - 28 test stderr files

### Verification
```
# SUMMARY
* Files with copyright information: 225 / 225
* Files with license information: 225 / 225

Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
```

Closes #300