### PR TITLE
291

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "masterror"
 version = "0.24.19"
 rust-version = "1.90"
 edition = "2024"
-license = "MIT OR Apache-2.0"
+license = "MIT"
 repository = "https://github.com/RAprogramm/masterror"
 readme = "README.md"
 description = "Application error types and response mapping"
@@ -26,8 +26,7 @@ include = [
   "README.ko.md",
   "README.template.md",
   "CHANGELOG.md",
-  "LICENSE-APACHE",
-  "LICENSE-MIT",
+  "LICENSE",
   "Makefile.toml",
   "deny.toml",
   "idea.md",
@@ -48,7 +47,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.90"
-license = "MIT OR Apache-2.0"
+license = "MIT"
 repository = "https://github.com/RAprogramm/masterror"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
   [![docs.rs](https://img.shields.io/docsrs/masterror)](https://docs.rs/masterror)
   [![Downloads](https://img.shields.io/crates/d/masterror)](https://crates.io/crates/masterror)
   ![MSRV](https://img.shields.io/badge/MSRV-1.90-blue)
-  ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
+  ![License](https://img.shields.io/badge/License-MIT-informational)
   [![REUSE status](https://api.reuse.software/badge/github.com/RAprogramm/masterror)](https://api.reuse.software/info/github.com/RAprogramm/masterror)
   [![codecov](https://codecov.io/gh/RAprogramm/masterror/graph/badge.svg?token=V9JQDTZLXH)](https://codecov.io/gh/RAprogramm/masterror)
 
@@ -643,6 +643,6 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 
 ## License
 
-MSRV: **1.90** · License: **MIT OR Apache-2.0** · No `unsafe`
+MSRV: **1.90** · License: **MIT** · No `unsafe`
 
 

--- a/README.template.md
+++ b/README.template.md
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
   [![docs.rs](https://img.shields.io/docsrs/masterror)](https://docs.rs/masterror)
   [![Downloads](https://img.shields.io/crates/d/masterror)](https://crates.io/crates/masterror)
   ![MSRV](https://img.shields.io/badge/MSRV-{{MSRV}}-blue)
-  ![License](https://img.shields.io/badge/License-MIT%20or%20Apache--2.0-informational)
+  ![License](https://img.shields.io/badge/License-MIT-informational)
   [![REUSE status](https://api.reuse.software/badge/github.com/RAprogramm/masterror)](https://api.reuse.software/info/github.com/RAprogramm/masterror)
   [![codecov](https://codecov.io/gh/RAprogramm/masterror/graph/badge.svg?token=V9JQDTZLXH)](https://codecov.io/gh/RAprogramm/masterror)
 
@@ -638,6 +638,6 @@ assert_eq!(problem.grpc.expect("grpc").name, "UNAUTHENTICATED");
 
 ## License
 
-MSRV: **{{MSRV}}** · License: **MIT OR Apache-2.0** · No `unsafe`
+MSRV: **{{MSRV}}** · License: **MIT** · No `unsafe`
 
 


### PR DESCRIPTION
## Summary

Removed Apache-2.0 license references to align with MIT-only licensing strategy per AI Development Protocol v2.1.

## Changes

**Cargo.toml**:
- Changed `license = "MIT OR Apache-2.0"` to `license = "MIT"` (package and workspace sections)
- Updated include list: removed `LICENSE-APACHE` and `LICENSE-MIT`, added `LICENSE` (symlink to LICENSES/MIT.txt)

**README.template.md**:
- Updated license badge from "MIT or Apache-2.0" to "MIT"
- Updated license footer from "MIT OR Apache-2.0" to "MIT"

**README.md**:
- Regenerated from template via build.rs with MIT-only references

## Verification

- [x] `reuse lint`: compliant (227/227 files)
- [x] `cargo test`: 429/429 tests passed
- [x] `cargo clippy`: no warnings
- [x] Pre-commit hooks: passed

## Rationale

Per AI Development Protocol v2.1, base license is MIT for open projects. Apache-2.0 was referenced in metadata but no Apache-2.0 license file existed. This change ensures consistency between declared license and actual license files.

Closes #291