### PR TITLE
#324 ci: auto-update CHANGELOG.md on release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -203,6 +203,27 @@ jobs:
           draft: false
           prerelease: false
 
+      - name: Update CHANGELOG.md
+        if: steps.version_check.outputs.should_release == 'true' && steps.check_existing.outputs.release_exists == 'false'
+        shell: bash
+        run: |
+          VERSION="${{ steps.local_version.outputs.version }}"
+
+          echo "Generating full CHANGELOG.md..."
+          git cliff --config cliff.toml --output CHANGELOG.md
+
+          if git diff --quiet CHANGELOG.md; then
+            echo "No changes to CHANGELOG.md, skipping commit"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add CHANGELOG.md
+          git commit -m "chore: update CHANGELOG.md for v${VERSION} [skip ci]"
+          git push origin main
+
       - name: Install Rust toolchain for publish
         if: steps.version_check.outputs.should_release == 'true'
         uses: dtolnay/rust-toolchain@v1


### PR DESCRIPTION
## Summary

Add automatic CHANGELOG.md update step to auto-release workflow.

## Problem

Currently auto-release.yml generates changelog using git-cliff for GitHub
release body, but CHANGELOG.md file in the repository is not updated automatically.

## Solution

After each successful release, CHANGELOG.md is now:
1. Generated with full history using git-cliff
2. Committed back to main branch
3. Uses [skip ci] flag to avoid triggering CI recursively

## Changes

- Add 'Update CHANGELOG.md' step in auto-release.yml after release creation
- Generate full changelog with git-cliff --output CHANGELOG.md
- Commit and push changes back to main branch
- Only runs if there are actual changes to commit

## Test Plan

- [x] Workflow syntax valid
- [x] All checks passing
- [ ] Test on actual release (will verify after merge)

Closes #324