### PR TITLE
326

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,28 @@ jobs:
       all-features: true
     secrets: inherit
 
+  no-std:
+    name: no_std compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: no-std
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Check no_std build
+        run: cargo check --no-default-features
+
   update-changelog:
-    needs: ci
+    needs: [ci, no-std]
     uses: ./.github/workflows/reusable-changelog.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/src/app_error/core/builder.rs
+++ b/src/app_error/core/builder.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-use alloc::{borrow::Cow, sync::Arc};
+use alloc::{borrow::Cow, string::String, sync::Arc};
 use core::error::Error as CoreError;
 #[cfg(feature = "backtrace")]
 use std::backtrace::Backtrace;

--- a/src/app_error/core/display.rs
+++ b/src/app_error/core/display.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+use alloc::string::ToString;
 use core::{
     error::Error as CoreError,
     fmt::{Formatter, Result as FmtResult},

--- a/src/app_error/core/introspection.rs
+++ b/src/app_error/core/introspection.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-use alloc::borrow::Cow;
+use alloc::{borrow::Cow, boxed::Box};
 use core::error::Error as CoreError;
 
 #[cfg(feature = "backtrace")]


### PR DESCRIPTION
## Summary

Fix no_std compilation broken in v0.25.0.

## Changes

Add missing `alloc` imports when `std` feature is disabled:

- **builder.rs:126,416** - Add `String` import
- **introspection.rs:238** - Add `Box` import  
- **display.rs:391** - Add `ToString` import
- **ci.yml** - Add no_std compatibility check

## Root Cause

v0.25.0 refactored core modules but missed adding `alloc` imports for no_std builds.

## Testing

- ✅ `cargo check --no-default-features` passes
- ✅ All 508 tests pass with std
- ✅ Added CI check to prevent future regressions

## Severity

**Critical** - Breaks no_std builds completely

Closes #326