### PR TITLE
446

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -72,7 +72,11 @@
 /// assert!(bounded(2, 3).is_ok());
 /// assert!(bounded(5, 3).is_err());
 /// ```
+///
+/// Clippy format-args lints (such as `clippy::uninlined_format_args`) see
+/// through this macro and lint format arguments passed inside it.
 #[macro_export]
+#[clippy::format_args]
 macro_rules! ensure {
     (cond = $cond:expr, else = $err:expr $(,)?) => {
         $crate::ensure!($cond, $err)
@@ -102,7 +106,11 @@ macro_rules! ensure {
 /// let err = reject().unwrap_err();
 /// assert!(matches!(err.kind, AppErrorKind::Unauthorized));
 /// ```
+///
+/// Clippy format-args lints (such as `clippy::uninlined_format_args`) see
+/// through this macro and lint format arguments passed inside it.
 #[macro_export]
+#[clippy::format_args]
 macro_rules! fail {
     ($err:expr $(,)?) => {
         return Err($err);
@@ -170,7 +178,11 @@ macro_rules! fail {
 ///     AppErrorKind::Unauthorized
 /// ));
 /// ```
+///
+/// Clippy format-args lints (such as `clippy::uninlined_format_args`) see
+/// through this macro and lint the format string and arguments directly.
 #[macro_export]
+#[clippy::format_args]
 macro_rules! app_error {
     ($kind:expr $(,)?) => {
         $crate::AppError::bare($kind)


### PR DESCRIPTION
Closes #446

Teaches clippy to lint format arguments inside the exported macros (`ensure!`, `fail!`, `app_error!`) — anyhow 1.0.100 parity.

Applied `#[clippy::format_args]` to the macro definitions. anyhow gates the attribute behind a build probe only for rustc < 1.85; masterror's MSRV is 1.96, so it's applied unconditionally — no build.rs changes.

Verification: scratch crate with a non-inlined format arg through `app_error!` — `clippy::uninlined_format_args` fires with the correct suggestion; negative control without the attribute produces no warning. Full workspace suite, clippy zero warnings, nightly fmt — all green. One file changed (+12 lines).