### PR TITLE
462

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,7 +1947,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "masterror"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "masterror-template",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "masterror"
-version = "0.28.0"
+version = "0.29.0"
 rust-version = "1.96"
 edition = "2024"
 license = "MIT"
@@ -89,11 +89,11 @@ openapi = ["dep:utoipa", "std"]
 benchmarks = ["std"]
 
 [workspace.dependencies]
-masterror-derive = { version = "0.11" }
+masterror-derive = { version = "0.12" }
 masterror-template = { version = "0.4" }
 
 [dependencies]
-masterror-derive = { version = "0.11" }
+masterror-derive = { version = "0.12" }
 masterror-template = { workspace = true }
 tracing = { version = "0.1", optional = true, default-features = false, features = [
   "attributes",

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ The build script keeps the full feature snippet below in sync with
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.28.0", default-features = false }
+masterror = { version = "0.29.0", default-features = false }
 # or with features:
-# masterror = { version = "0.28.0", features = [
+# masterror = { version = "0.29.0", features = [
 #   "std", "axum", "actix", "openapi",
 #   "serde_json", "tracing", "metrics", "backtrace",
 #   "colored", "sqlx", "sqlx-migrate", "reqwest",
@@ -697,7 +697,7 @@ never contains escape sequences:
 
 ~~~toml
 [dependencies]
-masterror = { version = "0.28.0", features = ["colored"] }
+masterror = { version = "0.29.0", features = ["colored"] }
 ~~~
 
 </details>

--- a/masterror-derive/Cargo.toml
+++ b/masterror-derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "masterror-derive"
 rust-version = "1.96"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/RAprogramm/masterror"


### PR DESCRIPTION
Closes #462

Release 0.29.0:

- masterror 0.28.0 → 0.29.0 — DisplayMode wired into Display (behavioral change in error output), real downcast/downcast_mut, app_error! expression macro, boxed error round-trip, clippy format-args lint transparency, source attachment in #[app_error] conversions with provider forwarding
- masterror-derive 0.11.3 → 0.12.0 — source-attaching From codegen + no_source flag + Send/Sync bounds (breaking for non-Send domain types), enum-level #[error(fmt = ...)], raw-ident r#source template fix, deprecated-type hygiene
- masterror-template unchanged

READMEs regenerated with the new version. Merging to main triggers the release pipeline.